### PR TITLE
use OSGeo4W DLL name 'geos_c' on Windows

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -1,6 +1,6 @@
 module LibGEOS
 
-    @unix_only const libgeos = "libgeos_c"
+    const libgeos = @unix ? "libgeos_c" : "geos_c"
 
     using Compat, GeoInterface
 


### PR DESCRIPTION
On the [OSGeo GEOS page](http://trac.osgeo.org/geos/) only OSGeo4W is suggested to get the binary. So does it make sense to use the [DLL name in OSGeo4W](http://trac.osgeo.org/osgeo4w/wiki/pkg-geos)?

With this it passes tests locally on Windows, otherwise I get an `ERROR: libgeos not defined` when loading LibGEOS.jl.