### PR TITLE
Buffer can also return a MultiPolygon, not only a Polygon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ julia:
     - 0.4
     - 0.5
     - nightly
+matrix:
+  allow_failures:
+    - julia: nightly 
 notifications:
     email: false
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ branches:
     - master
     - /release-.*/
 
+matrix:
+  allow_failures:
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 notifications:
   - provider: Email
     on_build_success: false

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -36,7 +36,7 @@ interpolateNormalized(line::LineString, dist::Real) = Point(interpolateNormalize
 # # Topology operations
 # # -----
 for geom in (:Point, :MultiPoint, :LineString, :MultiLineString, :LinearRing, :Polygon, :MultiPolygon, :GeometryCollection)
-    @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = Polygon(buffer(obj.ptr, dist, quadsegs))
+    @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = geomFromGEOS(buffer(obj.ptr, dist, quadsegs))
     @eval envelope(obj::$geom) = geomFromGEOS(envelope(obj.ptr))
     @eval convexhull(obj::$geom) = geomFromGEOS(convexhull(obj.ptr))
     @eval boundary(obj::$geom) = geomFromGEOS(boundary(obj.ptr))

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -242,3 +242,8 @@ test_within("POLYGON((1 1,1 2,2 2,2 1,1 1))", "MULTIPOLYGON(((0 0,0 10,10 10,10 
 # GEOSisClosedTest
 @fact isClosed(parseWKT("LINESTRING(0 0, 1 0, 1 1)")) --> false
 @fact isClosed(parseWKT("LINESTRING(0 0, 0 1, 1 1, 0 0)")) --> true
+
+# Buffer should return Polygon or MultiPolygon
+@fact typeof(buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 0.1)) --> :MultiPolygon
+@fact typeof(buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 10)) --> :Polygon
+@fact 2 --> 3

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -246,4 +246,3 @@ test_within("POLYGON((1 1,1 2,2 2,2 1,1 1))", "MULTIPOLYGON(((0 0,0 10,10 10,10 
 # Buffer should return Polygon or MultiPolygon
 @fact typeof(buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 0.1)) --> :MultiPolygon
 @fact typeof(buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 10)) --> :Polygon
-@fact 2 --> 3


### PR DESCRIPTION
```
using LibGEOS

A = [[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]
buffersize = 0.5
mp = MultiPoint(A)
buffer = buffer(mp, buffersize)
```

`buffer` should be a MultiPolygon, but is cast as Polygon. 
Calling the internal function `coordinates` on this "Polygon" will lead to a crash.