### PR TITLE
add error handler

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module LibGEOS
 
     if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
@@ -57,7 +59,9 @@ module LibGEOS
         finishGEOS()
     end
 
-    _connection = GEOSconnection()
+    function __init__()
+        global const _connection = GEOSconnection()
+    end
 
     include("geos_functions.jl")
     include("geos_types.jl")

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -16,4 +16,14 @@ facts("LibGEOS regressions") do
     mp = LibGEOS.MultiPoint(Vector{Float64}[[0,0],[10,0],[10,10],[11,10]])
     @fact GeoInterface.geotype(mp) --> :MultiPoint
 
+    # https://github.com/JuliaGeo/LibGEOS.jl/issues/20
+    # LibGEOS doesn't support Extended WKT
+    ewkt = "SRID=32756; POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
+    # ParseException: Unknown type: 'SRID=32756;'
+    @fact_throws LibGEOS.GEOSError parseWKT(ewkt)
+
+    # https://github.com/JuliaGeo/LibGEOS.jl/issues/40
+    # IllegalArgumentException: Points of LinearRing do not form a closed linestring
+    @fact_throws LibGEOS.GEOSError parseWKT("POLYGON((-1. 1., 1. 3., 0. 2., -1. 1.5))")
+
 end


### PR DESCRIPTION
Closes #41 

```julia
  | | |_| | | | (_| |  |  Version 0.6.0 (2017-06-19 13:05 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-apple-darwin13.4.0

julia> using LibGEOS; parseWKT("SRID=32756; POLYGON ((481676.5592297933180816 7207446.6192339314147830, 481670.9812610360677354 7207436.6032548164948821, 481656.8734335989574902 7207443.3182328715920448, 481661.5463352609076537 7207453.9481827337294817, 481676.5592297933180816 7207446.6192339314147830))")
ERROR: GEOSError
	ParseException: Unknown type: 'SRID=32756;'
Stacktrace:
 [1] geosjl_errorhandler(::Ptr{UInt8}, ::Ptr{Void}) at /Users/yeesian/.julia/v0.6/LibGEOS/src/LibGEOS.jl:34
 [2] geomFromWKT(::String) at /Users/yeesian/.julia/v0.6/LibGEOS/src/geos_functions.jl:19
 [3] parseWKT(::String) at /Users/yeesian/.julia/v0.6/LibGEOS/src/geos_operations.jl:25

julia> parseWKT("POLYGON((-1. 1., 1. 3., 0. 2., -1. 1.5))")
ERROR: GEOSError
	IllegalArgumentException: Points of LinearRing do not form a closed linestring
Stacktrace:
 [1] geosjl_errorhandler(::Ptr{UInt8}, ::Ptr{Void}) at /Users/yeesian/.julia/v0.6/LibGEOS/src/LibGEOS.jl:34
 [2] geomFromWKT(::String) at /Users/yeesian/.julia/v0.6/LibGEOS/src/geos_functions.jl:19
 [3] parseWKT(::String) at /Users/yeesian/.julia/v0.6/LibGEOS/src/geos_operations.jl:25
```