### PR TITLE
add bufferWithStyle

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -13,7 +13,7 @@ module LibGEOS
     export  Point, MultiPoint, LineString, MultiLineString, LinearRing, Polygon, MultiPolygon, GeometryCollection,
             parseWKT, geomFromWKT, geomToWKT, readgeom, writegeom,
             project, projectNormalized, interpolate, interpolateNormalized,
-            buffer, envelope, intersection, convexhull, difference, symmetricDifference,
+            buffer, bufferWithStyle, envelope, intersection, convexhull, difference, symmetricDifference,
             boundary, union, unaryUnion, pointOnSurface, centroid, node,
             polygonize, lineMerge, simplify, topologyPreserveSimplify, uniquePoints, sharedPaths,
             snap, delaunayTriangulation, delaunayTriangulationEdges,

--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -324,6 +324,9 @@ end
 buffer(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, context::GEOSContext = _context) =
     GEOSBuffer_r(context.ptr, ptr, width, Int32(quadsegs))
 
+bufferWithStyle(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, endCapStyle::Integer=1, joinStyle::Integer=1, mitreLimit::Real=5.0, context::GEOSContext = _context) =
+    GEOSBufferWithStyle_r(context.ptr, ptr, width, Int32(quadsegs), Int32(endCapStyle), Int32(joinStyle), mitreLimit)
+
 # enum GEOSBufCapStyles
 # enum GEOSBufJoinStyles
 
@@ -335,7 +338,6 @@ buffer(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, context::GEOSContext = _
 # GEOSBufferParams_setQuadrantSegments
 # GEOSBufferParams_setSingleSided
 # GEOSBufferWithParams
-# GEOSBufferWithStyle
 # GEOSOffsetCurve
 
 # -----

--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -324,11 +324,11 @@ end
 buffer(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, context::GEOSContext = _context) =
     GEOSBuffer_r(context.ptr, ptr, width, Int32(quadsegs))
 
-bufferWithStyle(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, endCapStyle::Integer=1, joinStyle::Integer=1, mitreLimit::Real=5.0, context::GEOSContext = _context) =
-    GEOSBufferWithStyle_r(context.ptr, ptr, width, Int32(quadsegs), Int32(endCapStyle), Int32(joinStyle), mitreLimit)
+@enum GEOSBufCapStyles::Int32 CAP_ROUND=1 CAP_FLAT=2 CAP_SQUARE=3
+@enum GEOSBufJoinStyles::Int32 JOIN_ROUND=1 JOIN_MITRE=2 JOIN_BEVEL=3
 
-# enum GEOSBufCapStyles
-# enum GEOSBufJoinStyles
+bufferWithStyle(ptr::GEOSGeom, width::Real, quadsegs::Integer=8, endCapStyle::GEOSBufCapStyles=CAP_ROUND, joinStyle::GEOSBufJoinStyles=JOIN_ROUND, mitreLimit::Real=5.0, context::GEOSContext = _context) =
+    GEOSBufferWithStyle_r(context.ptr, ptr, width, Int32(quadsegs), Int32(endCapStyle), Int32(joinStyle), mitreLimit)
 
 # GEOSBufferParams_create
 # GEOSBufferParams_destroy

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -56,7 +56,7 @@ interpolateNormalized(line::LineString, dist::Real) = Point(interpolateNormalize
 # # -----
 for geom in (:Point, :MultiPoint, :LineString, :MultiLineString, :LinearRing, :Polygon, :MultiPolygon, :GeometryCollection)
     @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = geomFromGEOS(buffer(obj.ptr, dist, quadsegs))
-    @eval bufferWithStyle(obj::$geom, dist::Real, quadsegs::Integer=8, endCapStyle::GEOSBufCapStyles=CAP_ROUND, joinStyle::GEOSBufJoinStyles=JOIN_ROUND, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
+    @eval bufferWithStyle(obj::$geom, dist::Real; quadsegs::Integer=8, endCapStyle::GEOSBufCapStyles=CAP_ROUND, joinStyle::GEOSBufJoinStyles=JOIN_ROUND, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
     @eval envelope(obj::$geom) = geomFromGEOS(envelope(obj.ptr))
     @eval convexhull(obj::$geom) = geomFromGEOS(convexhull(obj.ptr))
     @eval boundary(obj::$geom) = geomFromGEOS(boundary(obj.ptr))

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -56,6 +56,7 @@ interpolateNormalized(line::LineString, dist::Real) = Point(interpolateNormalize
 # # -----
 for geom in (:Point, :MultiPoint, :LineString, :MultiLineString, :LinearRing, :Polygon, :MultiPolygon, :GeometryCollection)
     @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = geomFromGEOS(buffer(obj.ptr, dist, quadsegs))
+    @eval bufferWithStyle(obj::$geom, dist::Real, quadsegs::Integer=8, endCapStyle::Integer=1, joinStyle::Integer=1, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
     @eval envelope(obj::$geom) = geomFromGEOS(envelope(obj.ptr))
     @eval convexhull(obj::$geom) = geomFromGEOS(convexhull(obj.ptr))
     @eval boundary(obj::$geom) = geomFromGEOS(boundary(obj.ptr))

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -56,7 +56,7 @@ interpolateNormalized(line::LineString, dist::Real) = Point(interpolateNormalize
 # # -----
 for geom in (:Point, :MultiPoint, :LineString, :MultiLineString, :LinearRing, :Polygon, :MultiPolygon, :GeometryCollection)
     @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = geomFromGEOS(buffer(obj.ptr, dist, quadsegs))
-    @eval bufferWithStyle(obj::$geom, dist::Real, quadsegs::Integer=8, endCapStyle::Integer=1, joinStyle::Integer=1, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
+    @eval bufferWithStyle(obj::$geom, dist::Real, quadsegs::Integer=8, endCapStyle::GEOSBufCapStyles=CAP_ROUND, joinStyle::GEOSBufJoinStyles=JOIN_ROUND, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
     @eval envelope(obj::$geom) = geomFromGEOS(envelope(obj.ptr))
     @eval convexhull(obj::$geom) = geomFromGEOS(convexhull(obj.ptr))
     @eval boundary(obj::$geom) = geomFromGEOS(boundary(obj.ptr))

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -247,4 +247,17 @@ end
     # Buffer should return Polygon or MultiPolygon
     @test buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 0.1) isa LibGEOS.MultiPolygon
     @test buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 10) isa LibGEOS.Polygon
+    
+    # bufferWithStyle
+    g1 = bufferWithStyle(readgeom("LINESTRING(0 0,0 1,1 1)"), 0.1, endCapStyle=LibGEOS.CAP_FLAT, joinStyle=LibGEOS.JOIN_BEVEL)
+    g2 = readgeom("POLYGON((-0.1 0.0,-0.1 1.0,0.0 1.1,1.0 1.1,1.0 0.9,0.1 0.9,0.1 0.0,-0.1 0.0))")
+    @test equals(g1, g2)
+    
+    g1 = bufferWithStyle(readgeom("LINESTRING(0 0,0 1,1 1)"), 0.1, endCapStyle=LibGEOS.CAP_SQUARE, joinStyle=LibGEOS.JOIN_MITRE)
+    g2 = readgeom("POLYGON((-0.1 -0.1,-0.1 1.1,1.1 1.1,1.1 0.9,0.1 0.9,0.1 -0.1,-0.1 -0.1))")
+    @test equals(g1, g2)
+
+    g1 = bufferWithStyle(readgeom("POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))"), 0.2, joinStyle=LibGEOS.JOIN_MITRE)
+    g2 = readgeom("POLYGON((-1.2 1.2,1.2 1.2,1.2 -1.2,-1.2 -1.2,-1.2 1.2))")
+    @test equals(g1, g2)
 end


### PR DESCRIPTION
Wrap `GEOSBufferWithStyle` as `bufferWithStyle` similarly like `GEOSBuffer` as `buffer`.

I set default for `mitreLimit` 5.0, same as in the library
https://github.com/libgeos/geos/blob/8a9600bb2e617c788fdcdad8eb9e9045925bbd23/src/operation/buffer/BufferParameters.cpp#L35

Defaults for `endCapStyle` 1 (CAP_ROUND) and `joinStyle` 1 (JOIN_ROUND). 