### PR TITLE
move Test dependency to extras

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,15 @@ CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 GEOS_jll = "d604d12d-fa86-5845-992e-78dc15976526"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CEnum = "0.2.0"
 GEOS_jll = "3.8.0"
 GeoInterface = "0.4.0"
 julia = "1.3.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
Small fix. Mainly used to test the new GEOS_jll binary at https://github.com/JuliaBinaryWrappers/GEOS_jll.jl/releases/tag/GEOS-v3.8.0%2B3 which just got registered and so will be picked up automatically.

This is the same GEOS version as before, but using a newer build, which resolved https://github.com/JuliaPackaging/Yggdrasil/issues/316.