### PR TITLE
add minimumRotatedRectangle-function

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -17,7 +17,7 @@ module LibGEOS
             prepdisjoint, prepintersects, prepoverlaps, preptouches, prepwithin,
             isEmpty, isSimple, isRing, hasZ, isClosed, isValid, interiorRings, exteriorRing,
             numPoints, startPoint, endPoint, area, geomLength, distance, hausdorffdistance, nearestPoints,
-            getPrecision, setPrecision
+            getPrecision, setPrecision, minimumRotatedRectangle
 
     include("geos_common.jl")
     include("geos_c.jl")

--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -402,6 +402,24 @@ function envelope(ptr::GEOSGeom, context::GEOSContext = _context)
     result
 end
 
+
+"""
+    minimumRotatedRectangle(geom)
+
+Returns the minimum rotated rectangular POLYGON which encloses the input geometry. The rectangle
+has width equal to the minimum diameter, and a longer length. If the convex hill of the input is
+degenerate (a line or point) a LINESTRING or POINT is returned. The minimum rotated rectangle can
+be used as an extremely generalized representation for the given geometry.
+"""
+function minimumRotatedRectangle(ptr::GEOSGeom, context::GEOSContext = _context)
+    result = GEOSMinimumRotatedRectangle_r(context.ptr, ptr)
+    if result == C_NULL
+        error("LibGEOS: Error in GEOSMinimumRotatedRectangle")
+    end
+    result
+end
+
+
 function intersection(g1::GEOSGeom, g2::GEOSGeom, context::GEOSContext = _context)
     result = GEOSIntersection_r(context.ptr, g1, g2)
     if result == C_NULL

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -58,6 +58,7 @@ for geom in (:Point, :MultiPoint, :LineString, :MultiLineString, :LinearRing, :P
     @eval buffer(obj::$geom, dist::Real, quadsegs::Integer=8) = geomFromGEOS(buffer(obj.ptr, dist, quadsegs))
     @eval bufferWithStyle(obj::$geom, dist::Real; quadsegs::Integer=8, endCapStyle::GEOSBufCapStyles=GEOSBUF_CAP_ROUND, joinStyle::GEOSBufJoinStyles=GEOSBUF_JOIN_ROUND, mitreLimit::Real=5.0) = geomFromGEOS(bufferWithStyle(obj.ptr, dist, quadsegs, endCapStyle, joinStyle, mitreLimit))
     @eval envelope(obj::$geom) = geomFromGEOS(envelope(obj.ptr))
+    @eval minimumRotatedRectangle(obj::$geom) = geomFromGEOS(minimumRotatedRectangle(obj.ptr))
     @eval convexhull(obj::$geom) = geomFromGEOS(convexhull(obj.ptr))
     @eval boundary(obj::$geom) = geomFromGEOS(boundary(obj.ptr))
     @eval unaryUnion(obj::$geom) = geomFromGEOS(unaryUnion(obj.ptr))

--- a/test/test_geos_functions.jl
+++ b/test/test_geos_functions.jl
@@ -730,5 +730,13 @@
     LibGEOS.destroyGeom(geom2_)
     LibGEOS.destroyGeom(geom3_)
     LibGEOS.destroyGeom(g)
-    
+
+    # GEOSMinimumRotatedRectangleTest
+    input_ = readgeom("POLYGON ((1 6, 6 11, 11 6, 6 1, 1 6))")
+    output_ = minimumRotatedRectangle(input_)
+    expected_ = readgeom("POLYGON ((6 1, 11 6, 6 11, 1 6, 6 1))")
+    @test writegeom(output_) == writegeom(expected_)
+    LibGEOS.destroyGeom(input_)
+    LibGEOS.destroyGeom(output_)
+    LibGEOS.destroyGeom(expected_)
 end


### PR DESCRIPTION
Wraps GEOSMinimumRotatedRectangle that was added to CAPI in LibGEOS 3.6.0.