### PR TITLE
Compatibility for Base.contains in Julia v1.5

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -12,12 +12,18 @@ module LibGEOS
             boundary, union, unaryUnion, pointOnSurface, centroid, node,
             polygonize, lineMerge, simplify, topologyPreserveSimplify, uniquePoints, sharedPaths,
             snap, delaunayTriangulation, delaunayTriangulationEdges,
-            disjoint, touches, intersects, crosses, within, contains, overlaps, equals, equalsexact, covers, coveredby,
+            disjoint, touches, intersects, crosses, within, overlaps, equals, equalsexact, covers, coveredby,
             prepareGeom, prepcontains, prepcontainsproperly, prepcoveredby, prepcovers, prepcrosses,
             prepdisjoint, prepintersects, prepoverlaps, preptouches, prepwithin,
             isEmpty, isSimple, isRing, hasZ, isClosed, isValid, interiorRings, exteriorRing,
             numPoints, startPoint, endPoint, area, geomLength, distance, hausdorffdistance, nearestPoints,
             getPrecision, setPrecision, minimumRotatedRectangle
+
+    if VERSION >= v"1.5.0-DEV.639"
+        import Base: contains
+    else
+        export contains
+    end
 
     include("geos_common.jl")
     include("geos_c.jl")


### PR DESCRIPTION
Version limit taken from https://github.com/Nemocas/Nemo.jl/blob/v0.17.5/src/Nemo.jl#L37-L39

Fixes https://github.com/JuliaGeo/LibGEOS.jl/issues/75