### PR TITLE
remove Libdl deps as it is not needed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.6.4"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 GEOS_jll = "d604d12d-fa86-5845-992e-78dc15976526"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 CEnum = "0.2, 0.3, 0.4"

--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -2,7 +2,6 @@ module LibGEOS
 
     using GEOS_jll
     using GeoInterface
-    using Libdl
     using CEnum
 
     export  Point, MultiPoint, LineString, MultiLineString, LinearRing, Polygon, MultiPolygon, GeometryCollection,


### PR DESCRIPTION
Apparently Libdl is not anymore when LibGEOS_jll is used as a dependency.