### PR TITLE
apply WKTWriter options after construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 LibGEOS.jl
 ==========
-[![Build Status](https://travis-ci.com/JuliaGeo/LibGEOS.jl.svg?branch=master)](https://travis-ci.com/JuliaGeo/LibGEOS.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaGeo/LibGEOS.jl?svg=true&branch=master)](https://ci.appveyor.com/project/JuliaGeo/LibGEOS-jl/branch/master)
+[![CI](https://github.com/JuliaGeo/LibGEOS.jl/workflows/CI/badge.svg)](https://github.com/JuliaGeo/LibGEOS.jl/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaGeo/LibGEOS.jl/badge.svg)](https://coveralls.io/github/JuliaGeo/LibGEOS.jl)
 
 LibGEOS is a package for manipulation and analysis of planar geometric objects, based on the libraries [GEOS](https://trac.osgeo.org/geos/) (the engine of PostGIS) and JTS (from which GEOS is ported). This package wraps the [GEOS C API](https://geos.osgeo.org/doxygen/geos__c_8h_source.html).

--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -72,11 +72,11 @@ module LibGEOS
 
         function WKTWriter(context::GEOSContext; trim::Bool=true, outputdim::Int=3, roundingprecision::Int=-1)
             writer = new(GEOSWKTWriter_create_r(context.ptr))
+            GEOSWKTWriter_setTrim_r(context.ptr, writer.ptr, UInt8(trim))
+            GEOSWKTWriter_setOutputDimension_r(context.ptr, writer.ptr, outputdim)
+            GEOSWKTWriter_setRoundingPrecision_r(context.ptr, writer.ptr, roundingprecision)
             finalizer(function(writer)
                 GEOSWKTWriter_destroy_r(context.ptr, writer.ptr)
-                GEOSWKTWriter_setTrim_r(context.ptr, writer.ptr, UInt8(trim))
-                GEOSWKTWriter_setOutputDimension_r(context.ptr, writer.ptr, outputdim)
-                GEOSWKTWriter_setRoundingPrecision_r(context.ptr, writer.ptr, roundingprecision)
                 writer.ptr = C_NULL
             end, writer)
             writer

--- a/test/test_geos_functions.jl
+++ b/test/test_geos_functions.jl
@@ -715,7 +715,7 @@ end
     geom_ = LibGEOS._readgeom("LINESTRING(0 0, 0 1, 1 1, 0 0)")
     @test LibGEOS.isClosed(geom_)
     LibGEOS.destroyGeom(geom_)
-    
+
     # setPrecision, getPrecision
     # Taken from https://git.osgeo.org/gitea/geos/geos/src/branch/master/tests/unit/capi/GEOSGeom_setPrecisionTest.cpp
 
@@ -755,7 +755,7 @@ end
     geom3_ = setPrecision(geom1_, 5.0, flags = LibGEOS.GEOS_PREC_KEEP_COLLAPSED)
     # @test equals(geom3_, readgeom("LINESTRING (0 0, 0 0)")) # false ??
     @test writegeom(geom3_) == "LINESTRING (0 0, 0 0)"
-    
+
     LibGEOS.destroyGeom(geom1_)
     LibGEOS.destroyGeom(geom2_)
     LibGEOS.destroyGeom(geom3_)

--- a/test/test_geos_functions.jl
+++ b/test/test_geos_functions.jl
@@ -1,3 +1,25 @@
+@testset "WKTWriter" begin
+    # default writing options
+    p = readgeom("POINT(0.12345 2.000 0.1)")
+    @test writegeom(p) == "POINT Z (0.12345 2 0.1)"
+
+    p = readgeom("POINT(0.12345 2.000)")
+    @test writegeom(p) == "POINT (0.12345 2)"
+
+    # round to 2 decimals
+    writer = LibGEOS.WKTWriter(LibGEOS._context, trim=true, outputdim=3, roundingprecision=2)
+    @test writegeom(p, writer) == "POINT (0.12 2)"
+
+    # round to 2 decimals and don't trim trailing zeros
+    writer = LibGEOS.WKTWriter(LibGEOS._context, trim=false, outputdim=3, roundingprecision=2)
+    @test writegeom(p, writer) == "POINT (0.12 2.00)"
+
+    # don't output the Z dimension
+    p = readgeom("POINT(0.12345 2.000 0.1)")
+    writer = LibGEOS.WKTWriter(LibGEOS._context, trim=false, outputdim=2, roundingprecision=2)
+    @test writegeom(p, writer) == "POINT (0.12 2.00)"
+end
+
 @testset "GEOS functions" begin
     a = LibGEOS.createCoordSeq(Vector{Float64}[[1,2,3],[4,5,6]])
     b = LibGEOS.cloneCoordSeq(a)

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -248,12 +248,12 @@ end
     # Buffer should return Polygon or MultiPolygon
     @test buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 0.1) isa LibGEOS.MultiPolygon
     @test buffer(MultiPoint([[1.0, 1.0], [2.0, 2.0], [2.0, 0.0]]), 10) isa LibGEOS.Polygon
-    
+
     # bufferWithStyle
     g1 = bufferWithStyle(readgeom("LINESTRING(0 0,0 1,1 1)"), 0.1, endCapStyle=LibGEOS.GEOSBUF_CAP_FLAT, joinStyle=LibGEOS.GEOSBUF_JOIN_BEVEL)
     g2 = readgeom("POLYGON((-0.1 0.0,-0.1 1.0,0.0 1.1,1.0 1.1,1.0 0.9,0.1 0.9,0.1 0.0,-0.1 0.0))")
     @test equals(g1, g2)
-    
+
     g1 = bufferWithStyle(readgeom("LINESTRING(0 0,0 1,1 1)"), 0.1, endCapStyle=LibGEOS.GEOSBUF_CAP_SQUARE, joinStyle=LibGEOS.GEOSBUF_JOIN_MITRE)
     g2 = readgeom("POLYGON((-0.1 -0.1,-0.1 1.1,1.1 1.1,1.1 0.9,0.1 0.9,0.1 -0.1,-0.1 -0.1))")
     @test equals(g1, g2)


### PR DESCRIPTION
Instead of after destruction :)

This means that `writegeom` will write a point like this:
```
"POINT (0.12345 2)"
```
where before it would print it like this:
```
"POINT (0.1234500000000000 2.0000000000000000)"
```