### PR TITLE
Upgrade versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -23,7 +23,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
@@ -41,6 +41,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 CEnum = "0.2, 0.3, 0.4"
 GEOS_jll = "3.9"
 GeoInterface = "0.4, 0.5"


### PR DESCRIPTION
Fixes #98

- Julia LTS version v1.3 to v1.6
- checkout: v2 to v3
- codecov-action: v1 to v2