### PR TITLE
remove evals

### DIFF
--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -1349,7 +1349,7 @@ The precision reduced result. Caller must free with `GEOSGeom_destroy()` NULL on
 function setPrecision(
     geom::GEOSGeom,
     gridSize::Real,
-    flags::GEOSPrecisionRules,
+    flags::Union{GEOSPrecisionRules,Integer},
     context::GEOSContext = _context,
 )
     result = geomFromGEOS(GEOSGeom_setPrecision_r(context.ptr, geom, gridSize, flags))
@@ -1357,15 +1357,4 @@ function setPrecision(
         error("LibGEOS: Error in GEOSGeom_setPrecision_r")
     end
     result
-end
-@eval function setPrecision(
-    geom::GEOSGeom,
-    gridSize::Real,
-    flags::Int,
-    context::GEOSContext = _context,
-)
-    !(flags in $(Int.(instances(GEOSPrecisionRules)))) && error(
-        "flags value should be in $(Int.(instances(GEOSPrecisionRules))) or use GEOSPrecisionRules enum members",
-    )
-    return setPrecision(geom, gridSize, GEOSPrecisionRules(flags), context)
 end

--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -271,7 +271,7 @@ function getCoordinates(ptr::GEOSCoordSeq, context::GEOSContext = _context)
     coordseq
 end
 
-function isCCW(ptr::GEOSCoordSeq, context::GEOSContext=_context)::Bool
+function isCCW(ptr::GEOSCoordSeq, context::GEOSContext = _context)::Bool
     d = UInt8[1]
     GC.@preserve result = GEOSCoordSeq_isCCW_r(context.ptr, ptr, pointer(d))
     if result == C_NULL
@@ -642,10 +642,7 @@ function delaunayTriangulation(
     result
 end
 
-function constrainedDelaunayTriangulation(
-    ptr::GEOSGeom,
-    context::GEOSContext = _context,
-)
+function constrainedDelaunayTriangulation(ptr::GEOSGeom, context::GEOSContext = _context)
     result = GEOSConstrainedDelaunayTriangulation_r(context.ptr, ptr)
     if result == C_NULL
         error("LibGEOS: Error in GEOSConstrainedDelaunayTriangulation")

--- a/src/geos_operations.jl
+++ b/src/geos_operations.jl
@@ -73,8 +73,7 @@ readgeom(wkbbuffer::Vector{Cuchar}, context::GEOSContext = _context) =
 # Linear referencing functions -- there are more, but these are probably sufficient for most purposes
 # -----
 project(line::LineString, point::Point) = project(line.ptr, point.ptr)
-projectNormalized(line::LineString, point::Point) =
-    projectNormalized(line.ptr, point.ptr)
+projectNormalized(line::LineString, point::Point) = projectNormalized(line.ptr, point.ptr)
 interpolate(line::LineString, dist::Real) = Point(interpolate(line.ptr, dist))
 interpolateNormalized(line::LineString, dist::Real) =
     Point(interpolateNormalized(line.ptr, dist))
@@ -346,7 +345,7 @@ isClosed(obj::LineString) = isClosed(obj.ptr) # Call only on LINESTRING
 # # Geometry info
 # # -----
 
-# Gets the number of sub-geometries 
+# Gets the number of sub-geometries
 for geom in (
     :Point,
     :MultiPoint,

--- a/src/geos_types.jl
+++ b/src/geos_types.jl
@@ -129,22 +129,20 @@ mutable struct GeometryCollection <: GeoInterface.AbstractGeometryCollection
         GeometryCollection(createCollection(GEOS_GEOMETRYCOLLECTION, collection))
 end
 
-for geom in (
-    :Point,
-    :MultiPoint,
-    :LineString,
-    :MultiLineString,
-    :LinearRing,
-    :Polygon,
-    :MultiPolygon,
-    :GeometryCollection,
-)
-    @eval begin
-        function destroyGeom(obj::$geom, context::GEOSContext = _context)
-            destroyGeom(obj.ptr, context)
-            obj.ptr = C_NULL
-        end
-    end
+const Geometry = Union{
+    Point,
+    MultiPoint,
+    LineString,
+    MultiLineString,
+    LinearRing,
+    Polygon,
+    MultiPolygon,
+    GeometryCollection,
+}
+
+function destroyGeom(obj::Geometry, context::GEOSContext = _context)
+    destroyGeom(obj.ptr, context)
+    obj.ptr = C_NULL
 end
 
 mutable struct PreparedGeometry{G<:GeoInterface.AbstractGeometry} <:

--- a/test/test_geos_functions.jl
+++ b/test/test_geos_functions.jl
@@ -833,7 +833,9 @@ end
           writegeom(setPrecision(geom1_, 5.0; flags = 1))
     @test writegeom(setPrecision(geom1_, 5.0; flags = LibGEOS.GEOS_PREC_KEEP_COLLAPSED)) ==
           writegeom(setPrecision(geom1_, 5.0; flags = 2))
-    @test_throws ErrorException setPrecision(geom1_, 5.0; flags = 3)
+    bitwise_or_flag = LibGEOS.GEOS_PREC_NO_TOPO | LibGEOS.GEOS_PREC_KEEP_COLLAPSED
+    @test writegeom(setPrecision(geom1_, 5.0; flags = bitwise_or_flag)) ==
+          writegeom(setPrecision(geom1_, 5.0; flags = 0x03))
 
     LibGEOS.destroyGeom(geom1_)
     LibGEOS.destroyGeom(geom2_)

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -84,7 +84,10 @@ end
 
     g1 = readgeom("POLYGON ((10 10, 20 40, 90 90, 90 10, 10 10))")
     g2 = constrainedDelaunayTriangulation(g1)
-    equivalent_to_wkt(g2, "GEOMETRYCOLLECTION (POLYGON ((10 10, 20 40, 90 10, 10 10)), POLYGON ((90 90, 20 40, 90 10, 90 90)))")
+    equivalent_to_wkt(
+        g2,
+        "GEOMETRYCOLLECTION (POLYGON ((10 10, 20 40, 90 10, 10 10)), POLYGON ((90 90, 20 40, 90 10, 90 90)))",
+    )
 
     # GEOSDistanceTest
     g1 = readgeom("POINT(10 10)")


### PR DESCRIPTION
Fixes #105

This replaces this pattern:

```julia
for geom in (
    :Point,
    :MultiPoint,
    :LineString,
    :MultiLineString,
    :LinearRing,
    :Polygon,
    :MultiPolygon,
    :GeometryCollection,
)
    @eval getXMin(obj::$geom, context::GEOSContext = _context) = getXMin(obj.ptr, context)
end
```

With this:
```julia
getXMin(obj::Geometry, context::GEOSContext = _context) = getXMin(obj.ptr, context)
```

Where `Geometry` was already defined as:
```julia
const Geometry = Union{
    Point,
    MultiPoint,
    LineString,
    MultiLineString,
    LinearRing,
    Polygon,
    MultiPolygon,
    GeometryCollection,
}
```

So instead of having one method per geometry type, there is just one for all of them. According to https://github.com/JuliaGeo/LibGEOS.jl/pull/95#issuecomment-1058868759 it specializes fine.

Everything except the last one is a simple replace that shouldn't change any behavior. The last one is separated in 3c9a7f7fe562d402f168c9a95da688afc063da53 and should allow some new functionality.