### PR TITLE
Differentiate between `Base.convert` and `GeoInterface.convert`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibGEOS"
 uuid = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
 license = "MIT"
-version = "0.7.4"
+version = "0.8.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -71,26 +71,26 @@ function Base.convert(::Type{T}, geom::X) where {T<:AbstractGeometry,X}
     return Base.convert(T, GeoInterface.geomtrait(geom), geom)
 end
 
-function Base.convert(::Type{Point}, type::PointTrait, geom)
+function GeoInterface.convert(::Type{Point}, type::PointTrait, geom)
     return Point(GeoInterface.coordinates(geom))
 end
-function Base.convert(::Type{MultiPoint}, type::MultiPointTrait, geom)
+function GeoInterface.convert(::Type{MultiPoint}, type::MultiPointTrait, geom)
     return MultiPoint(GeoInterface.coordinates(geom))
 end
-function Base.convert(::Type{LineString}, type::LineStringTrait, geom)
+function GeoInterface.convert(::Type{LineString}, type::LineStringTrait, geom)
     return LineString(GeoInterface.coordinates(geom))
 end
-function Base.convert(::Type{MultiLineString}, type::MultiLineStringTrait, geom)
+function GeoInterface.convert(::Type{MultiLineString}, type::MultiLineStringTrait, geom)
     return MultiLineString(GeoInterface.coordinates(geom))
 end
-function Base.convert(::Type{Polygon}, type::PolygonTrait, geom)
+function GeoInterface.convert(::Type{Polygon}, type::PolygonTrait, geom)
     return Polygon(GeoInterface.coordinates(geom))
 end
-function Base.convert(::Type{MultiPolygon}, type::MultiPolygonTrait, geom)
+function GeoInterface.convert(::Type{MultiPolygon}, type::MultiPolygonTrait, geom)
     return MultiPolygon(GeoInterface.coordinates(geom))
 end
 
-function Base.convert(t::Type{<:AbstractGeometry}, type::AbstractGeometryTrait, geom)
+function GeoInterface.convert(t::Type{<:AbstractGeometry}, type::AbstractGeometryTrait, geom)
     error(
         "Cannot convert an object of $(typeof(geom)) with the $(typeof(type)) trait to a $t (yet). Please report an issue.",
     )

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -217,7 +217,7 @@ using Plots
         coords = [0.0, 0]
         GeoInterface.geomtrait(::XPoint) = GeoInterface.PointTrait()
         GeoInterface.coordinates(::XPoint) = coords
-        geom = convert(Point, XPoint())
+        geom = GeoInterface.convert(Point, XPoint())
         @test geom isa Point
         @test GeoInterface.coordinates(geom) == coords
 
@@ -225,7 +225,7 @@ using Plots
         coords = [[0.0, 0], [0.0, 10]]
         GeoInterface.geomtrait(::XMultiPoint) = GeoInterface.MultiPointTrait()
         GeoInterface.coordinates(::XMultiPoint) = coords
-        geom = convert(MultiPoint, XMultiPoint())
+        geom = GeoInterface.convert(MultiPoint, XMultiPoint())
         @test geom isa MultiPoint
         @test GeoInterface.coordinates(geom) == coords
 
@@ -233,7 +233,7 @@ using Plots
         coords = [[0.0, 0], [0.0, 10], [10.0, 10], [10.0, 0], [0.0, 0]]
         GeoInterface.geomtrait(::XLineString) = GeoInterface.LineStringTrait()
         GeoInterface.coordinates(::XLineString) = coords
-        geom = convert(LineString, XLineString())
+        geom = GeoInterface.convert(LineString, XLineString())
         @test geom isa LineString
         @test GeoInterface.coordinates(geom) == coords
 
@@ -241,7 +241,7 @@ using Plots
         coords = [[[0.0, 0], [0.0, 10], [10.0, 10], [10.0, 0], [0.0, 0]]]
         GeoInterface.geomtrait(::XMultiLineString) = GeoInterface.MultiLineStringTrait()
         GeoInterface.coordinates(::XMultiLineString) = coords
-        geom = convert(MultiLineString, XMultiLineString())
+        geom = GeoInterface.convert(MultiLineString, XMultiLineString())
         @test geom isa MultiLineString
         @test GeoInterface.coordinates(geom) == coords
 
@@ -249,7 +249,7 @@ using Plots
         coords = [[[0.0, 0], [0.0, 10], [10.0, 10], [10.0, 0], [0.0, 0]]]
         GeoInterface.geomtrait(::XPolygon) = GeoInterface.PolygonTrait()
         GeoInterface.coordinates(::XPolygon) = coords
-        geom = convert(Polygon, XPolygon())
+        geom = GeoInterface.convert(Polygon, XPolygon())
         @test geom isa Polygon
         @test GeoInterface.ngeom(geom) == 1
         @test GeoInterface.nring(geom) == 1
@@ -264,13 +264,13 @@ using Plots
         coords = [[[[0.0, 0], [0.0, 10], [10.0, 10], [10.0, 0], [0.0, 0]]]]
         GeoInterface.geomtrait(::XMultiPolygon) = GeoInterface.MultiPolygonTrait()
         GeoInterface.coordinates(::XMultiPolygon) = coords
-        geom = convert(MultiPolygon, XMultiPolygon())
+        geom = GeoInterface.convert(MultiPolygon, XMultiPolygon())
         @test geom isa MultiPolygon
         @test GeoInterface.coordinates(geom) == coords
 
         struct XMesh end
         GeoInterface.geomtrait(::XMesh) = GeoInterface.PolyhedralSurfaceTrait()
-        @test_throws Exception convert(MultiPolygon, XMesh())
+        @test_throws Exception GeoInterface.convert(MultiPolygon, XMesh())
 
     end
 


### PR DESCRIPTION
It is my understanding, that at some point in the past `Base.convert === GeoInterface.convert`. However, these are two different functions nowadays and we overload `Base.convert` where `GeoInterface.convert` would be the correct protocol in some cases.