### PR TITLE
Refactor GeoInterface implementation.

### DIFF
--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -10,54 +10,54 @@ GeoInterface.geomtrait(::MultiPolygon) = MultiPolygonTrait()
 GeoInterface.geomtrait(::GeometryCollection) = GeometryCollectionTrait()
 GeoInterface.geomtrait(geom::PreparedGeometry) = GeoInterface.geomtrait(geom.ownedby)
 
-GeoInterface.ngeom(::AbstractGeometryTrait, geom::AbstractGeometry) =
-    isEmpty(geom) ? 0 : numGeometries(geom)
-GeoInterface.ngeom(::AbstractPointTrait, geom::AbstractGeometry) = 0
+GeoInterface.ngeom(::AbstractGeometryCollectionTrait, geom::T) where {T<:AbstractMultiGeometry} =
+    isEmpty(geom) ? 0 : Int(numGeometries(geom))
+GeoInterface.ngeom(::LineStringTrait, geom::LineString) = Int(numPoints(geom))
+GeoInterface.ngeom(::LinearRingTrait, geom::LinearRing) = Int(numPoints(geom))
+GeoInterface.ngeom(::PolygonTrait, geom::Polygon) = Int(numInteriorRings(geom)) + 1
+GeoInterface.ngeom(t::AbstractGeometryTrait, geom::PreparedGeometry) =
+    GeoInterface.ngeom(t, geom.ownedby)
+GeoInterface.ngeom(::AbstractPointTrait, geom::Point) = 0
+GeoInterface.ngeom(::AbstractPointTrait, geom::PreparedGeometry) = 0
 
-function GeoInterface.getgeom(::AbstractGeometryTrait, geom::AbstractGeometry, i)
+function GeoInterface.getgeom(::AbstractGeometryCollectionTrait, geom::AbstractMultiGeometry, i)
     getGeometry(geom, i)
 end
-
-GeoInterface.getgeom(::AbstractPointTrait, geom::AbstractGeometry, i) = nothing
-GeoInterface.ngeom(::AbstractGeometryTrait, geom::Union{LineString,LinearRing}) =
-    numPoints(geom)
-GeoInterface.ngeom(t::AbstractPointTrait, geom::Union{LineString,LinearRing}) = 0
-GeoInterface.getgeom(::AbstractGeometryTrait, geom::Union{LineString,LinearRing}, i) =
+GeoInterface.getgeom(::MultiPointTrait, geom::MultiPoint, i) = getGeometry(geom, i)::Point
+GeoInterface.getgeom(::MultiLineStringTrait, geom::MultiLineString, i) = getGeometry(geom, i)::LineString
+GeoInterface.getgeom(::MultiPolygonTrait, geom::MultiPolygon, i) = getGeometry(geom, i)::Polygon
+GeoInterface.getgeom(::Union{LineStringTrait,LinearRingTrait}, geom::Union{LineString,LinearRing}, i) =
     Point(getPoint(geom, i))
-GeoInterface.getgeom(::AbstractPointTrait, geom::Union{LineString,LinearRing}, i) = nothing
-
-GeoInterface.ngeom(::AbstractGeometryTrait, geom::Polygon) = numInteriorRings(geom) + 1
-GeoInterface.ngeom(::AbstractPointTrait, geom::Polygon) = 0
-function GeoInterface.getgeom(::AbstractGeometryTrait, geom::Polygon, i)
+GeoInterface.getgeom(t::AbstractPointTrait, geom::PreparedGeometry) = nothing
+function GeoInterface.getgeom(::PolygonTrait, geom::Polygon, i::Int)
     if i == 1
         LinearRing(exteriorRing(geom))
     else
         LinearRing(interiorRing(geom, i - 1))
     end
 end
-GeoInterface.getgeom(::AbstractPointTrait, geom::Polygon, i) = nothing
-
-GeoInterface.ngeom(t::AbstractGeometryTrait, geom::PreparedGeometry) =
-    GeoInterface.ngeom(t, geom.ownedby)
-GeoInterface.ngeom(t::AbstractPointTrait, geom::PreparedGeometry) = 0
 GeoInterface.getgeom(t::AbstractGeometryTrait, geom::PreparedGeometry, i) =
     GeoInterface.getgeom(t, geom.ownedby, i)
 GeoInterface.getgeom(t::AbstractPointTrait, geom::PreparedGeometry, i) = 0
 
-GeoInterface.ncoord(::AbstractGeometryTrait, geom::AbstractGeometry) =
-    isEmpty(geom) ? 0 : getCoordinateDimension(geom)
-GeoInterface.getcoord(::AbstractGeometryTrait, geom::AbstractGeometry, i) =
-    getCoordinates(getCoordSeq(geom), 1)[i]
+# GeoInterface.coordinates(t::PointTrait, geom::Point) where {T<:AbstractGeometry} = collect(getcoord(geom))
+# GeoInterface.coordinates(t::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry} = [GeoInterface.coordinates(x) for x in getgeom(t, geom)]
+GeoInterface.coordinates(t::AbstractGeometryCollectionTrait, geom::T) where {T<:AbstractMultiGeometry} = [GeoInterface.coordinates(x) for x in getgeom(t, geom)]
 
+GeoInterface.ncoord(::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry} =
+    isEmpty(geom) ? 0 : Int(getCoordinateDimension(geom))
 GeoInterface.ncoord(t::AbstractGeometryTrait, geom::PreparedGeometry) =
     GeoInterface.ncoord(t, geom.ownedby)
+
+GeoInterface.getcoord(::AbstractGeometryTrait, geom::AbstractGeometry, i) =
+    getCoordinates(getCoordSeq(geom), 1)[i]
 GeoInterface.getcoord(t::AbstractGeometryTrait, geom::PreparedGeometry, i) =
     GeoInterface.getcoord(t, geom.ownedby, i)
 
-function GeoInterface.extent(::AbstractGeometryTrait, geom::AbstractGeometry)
+function GeoInterface.extent(::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry}
     # minx, miny, maxx, maxy = getExtent(geom)
     env = envelope(geom)
-    return Extent(X = (getXMin(env), getXMax(env)), Y = (getYMin(env), getYMax(env)))
+    return Extent(X=(getXMin(env), getXMax(env)), Y=(getYMin(env), getYMax(env)))
 end
 
 function Base.convert(::Type{T}, geom::T) where {T<:AbstractGeometry}

--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -40,8 +40,9 @@ GeoInterface.getgeom(t::AbstractGeometryTrait, geom::PreparedGeometry, i) =
     GeoInterface.getgeom(t, geom.ownedby, i)
 GeoInterface.getgeom(t::AbstractPointTrait, geom::PreparedGeometry, i) = 0
 
-# GeoInterface.coordinates(t::PointTrait, geom::Point) where {T<:AbstractGeometry} = collect(getcoord(geom))
-# GeoInterface.coordinates(t::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry} = [GeoInterface.coordinates(x) for x in getgeom(t, geom)]
+GeoInterface.coordinates(t::AbstractPointTrait, geom::Point) = collect(getcoord(t, geom))
+GeoInterface.coordinates(t::AbstractPointTrait, geom::T) where {T<:AbstractGeometry} = nothing
+GeoInterface.coordinates(t::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry} = [GeoInterface.coordinates(x) for x in getgeom(t, geom)]
 GeoInterface.coordinates(t::AbstractGeometryCollectionTrait, geom::T) where {T<:AbstractMultiGeometry} = [GeoInterface.coordinates(x) for x in getgeom(t, geom)]
 
 GeoInterface.ncoord(::AbstractGeometryTrait, geom::T) where {T<:AbstractGeometry} =

--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -19,10 +19,8 @@ GeoInterface.geomtrait(::MultiPolygon) = MultiPolygonTrait()
 GeoInterface.geomtrait(::GeometryCollection) = GeometryCollectionTrait()
 GeoInterface.geomtrait(geom::PreparedGeometry) = GeoInterface.geomtrait(geom.ownedby)
 
-GeoInterface.ngeom(
-    ::AbstractGeometryCollectionTrait,
-    geom::T,
-) where {T<:AbstractMultiGeometry} = isEmpty(geom) ? 0 : Int(numGeometries(geom))
+GeoInterface.ngeom(::AbstractGeometryCollectionTrait, geom::AbstractMultiGeometry) =
+    isEmpty(geom) ? 0 : Int(numGeometries(geom))
 GeoInterface.ngeom(::LineStringTrait, geom::LineString) = Int(numPoints(geom))
 GeoInterface.ngeom(::LinearRingTrait, geom::LinearRing) = Int(numPoints(geom))
 GeoInterface.ngeom(::PolygonTrait, geom::Polygon) = Int(numInteriorRings(geom)) + 1

--- a/src/geos_types.jl
+++ b/src/geos_types.jl
@@ -1,4 +1,5 @@
 abstract type AbstractGeometry end
+abstract type AbstractMultiGeometry <: AbstractGeometry end
 
 function Base.show(io::IO, geo::AbstractGeometry)
     compact = get(io, :compact, false)
@@ -34,7 +35,7 @@ mutable struct Point <: AbstractGeometry
         Point(createPoint(x, y, z, context), context)
 end
 
-mutable struct MultiPoint <: AbstractGeometry
+mutable struct MultiPoint <: AbstractMultiGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a multipoint from a pointer - only makes sense if it is a pointer to a multipoint
@@ -97,7 +98,7 @@ mutable struct LineString <: AbstractGeometry
     end
 end
 
-mutable struct MultiLineString <: AbstractGeometry
+mutable struct MultiLineString <: AbstractMultiGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a multiline string from a multilinestring or a linestring pointer, else error
@@ -186,7 +187,7 @@ mutable struct Polygon <: AbstractGeometry
             context)
 end
 
-mutable struct MultiPolygon <: AbstractGeometry
+mutable struct MultiPolygon <: AbstractMultiGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create multipolygon using a multipolygon or polygon pointer, else error
@@ -233,7 +234,7 @@ mutable struct MultiPolygon <: AbstractGeometry
             context)
 end
 
-mutable struct GeometryCollection <: AbstractGeometry
+mutable struct GeometryCollection <: AbstractMultiGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a geometric collection from a pointer to a geometric collection, else error

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -7,13 +7,18 @@ using Plots
     @test GeoInterface.ncoord(pt) == 2
     @test GeoInterface.getcoord(pt, 1) ≈ 1.0
     @test GeoInterface.testgeometry(pt)
-    @test GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y = (2.0, 2.0))
+    @test GeoInterface.extent(pt) == Extent(X=(1.0, 1.0), Y=(2.0, 2.0))
     plot(pt)
 
     pt = LibGEOS.Point(1, 2)
     @test GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
     @test GeoInterface.geomtrait(pt) == PointTrait()
     @test GeoInterface.testgeometry(pt)
+
+    @inferred GeoInterface.ncoord(pt)
+    @inferred GeoInterface.ngeom(pt)
+    @inferred GeoInterface.getgeom(pt)
+    @inferred GeoInterface.coordinates(pt)
 
     pt = LibGEOS.readgeom("POINT EMPTY")
     @test GeoInterface.coordinates(pt) ≈ Float64[] atol = 1e-5
@@ -32,6 +37,11 @@ using Plots
     @test GeoInterface.testgeometry(mpt)
     plot(mpt)
 
+    @inferred GeoInterface.ncoord(mpt)
+    @inferred GeoInterface.ngeom(mpt)
+    @inferred GeoInterface.getgeom(mpt)
+    @inferred GeoInterface.coordinates(mpt)
+
     coords = Vector{Float64}[[8, 1], [9, 1], [9, 2], [8, 2]]
     ls = LibGEOS.LineString(coords)
     @test GeoInterface.coordinates(ls) == coords
@@ -42,6 +52,11 @@ using Plots
     @test GeoInterface.coordinates(p) == [9, 2]
     @test GeoInterface.testgeometry(ls)
     plot(ls)
+
+    @inferred GeoInterface.ncoord(ls)
+    @inferred GeoInterface.ngeom(ls)
+    @inferred GeoInterface.getgeom(ls)
+    @inferred GeoInterface.coordinates(ls)
 
     ls = LibGEOS.readgeom("LINESTRING EMPTY")
     @test GeoInterface.coordinates(ls) == []
@@ -55,6 +70,11 @@ using Plots
     @test GeoInterface.testgeometry(mls)
     plot(mls)
 
+    @inferred GeoInterface.ncoord(mls)
+    @inferred GeoInterface.ngeom(mls)
+    @inferred GeoInterface.getgeom(mls)
+    @inferred GeoInterface.coordinates(mls)
+
     coords = Vector{Float64}[[8, 1], [9, 1], [9, 2], [8, 2], [8, 1]]
     lr = LibGEOS.LinearRing(coords)
     @test GeoInterface.coordinates(lr) == coords
@@ -66,6 +86,11 @@ using Plots
     @test GeoInterface.testgeometry(lr)
     # Cannot convert LinearRingTrait to series data for plotting
     # plot(lr)
+
+    @inferred GeoInterface.ncoord(lr)
+    @inferred GeoInterface.ngeom(lr)
+    @inferred GeoInterface.getgeom(lr)
+    @inferred GeoInterface.coordinates(lr)
 
     coords = Vector{Vector{Float64}}[
         Vector{Float64}[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
@@ -81,6 +106,11 @@ using Plots
     @test GeoInterface.coordinates(ls) == coords[2]
     @test GeoInterface.testgeometry(polygon)
     plot(polygon)
+
+    @inferred GeoInterface.ncoord(polygon)
+    @inferred GeoInterface.ngeom(polygon)
+    @inferred GeoInterface.getgeom(polygon)
+    @inferred GeoInterface.coordinates(polygon)
 
     polygon = LibGEOS.readgeom("POLYGON EMPTY")
     @test GeoInterface.coordinates(polygon) == [[]]
@@ -98,13 +128,18 @@ using Plots
     ]]]
     @test GeoInterface.geomtrait(multipolygon) == MultiPolygonTrait()
     @test GeoInterface.testgeometry(multipolygon)
-    @test GeoInterface.extent(multipolygon) == Extent(X = (0.0, 10.0), Y = (0.0, 10.0))
+    @test GeoInterface.extent(multipolygon) == Extent(X=(0.0, 10.0), Y=(0.0, 10.0))
     plot(multipolygon)
+
+    @inferred GeoInterface.ncoord(multipolygon)
+    @inferred GeoInterface.ngeom(multipolygon)
+    @inferred GeoInterface.getgeom(multipolygon)
+    @inferred GeoInterface.coordinates(multipolygon)
 
     pmultipolygon = LibGEOS.prepareGeom(multipolygon)
     @test GeoInterface.geomtrait(pmultipolygon) == MultiPolygonTrait()
     @test GeoInterface.testgeometry(pmultipolygon)
-    @test GeoInterface.extent(pmultipolygon) == Extent(X = (0.0, 10.0), Y = (0.0, 10.0))
+    @test GeoInterface.extent(pmultipolygon) == Extent(X=(0.0, 10.0), Y=(0.0, 10.0))
     LibGEOS.destroyGeom(pmultipolygon)
 
     geomcollection = LibGEOS.readgeom(
@@ -178,6 +213,11 @@ using Plots
     @test GeoInterface.geomtrait(geomcollection) == GeometryCollectionTrait()
     @test GeoInterface.testgeometry(geomcollection)
     plot(geomcollection)
+
+    @inferred GeoInterface.ncoord(geomcollection)
+    @inferred GeoInterface.ngeom(geomcollection)
+    @inferred GeoInterface.getgeom(geomcollection)
+    # @inferred GeoInterface.coordinates(geomcollection)  # can't be inferred
 
     geomcollection = LibGEOS.readgeom(
         "GEOMETRYCOLLECTION(MULTIPOINT(0 0, 0 0, 1 1),LINESTRING(1 1, 2 2, 2 2, 0 0),POLYGON((5 5, 0 0, 0 2, 2 2, 5 5)))",


### PR DESCRIPTION
Should partially fix #160.

Made ngeom to be stable, was a Union{Int64, Int32} before. `coordinates(multipolygon)` can now be correctly inferred.

It's a bit ugly to define thing(AbstractPoint, NonPoint), but it's required for the ambiguity checks. Might be good to understand why this is required.

Similarly, redefining `coordinates` here for both all geometries and multigeometries makes it inferrable. Julia really doesn't seem to like type inference through recursion.