### PR TITLE
Fix GeoInterface x y z

### DIFF
--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -53,10 +53,6 @@ GeoInterface.getgeom(t::AbstractGeometryTrait, geom::PreparedGeometry, i) =
     GeoInterface.getgeom(t, geom.ownedby, i)
 GeoInterface.getgeom(t::AbstractPointTrait, geom::PreparedGeometry, i) = 0
 
-GeoInterface.x(::AbstractPointTrait, geom::AbstractGeometry) = getX(geom.ptr, 1, get_context(geom))
-GeoInterface.y(::AbstractPointTrait, geom::AbstractGeometry) = getY(geom.ptr, 1, get_context(geom))
-GeoInterface.z(::AbstractPointTrait, geom::AbstractGeometry) = getZ(geom.ptr, 1, get_context(geom))
-
 GeoInterface.ncoord(::AbstractGeometryTrait, geom::AbstractGeometry) =
     isEmpty(geom) ? 0 : getCoordinateDimension(geom)
 GeoInterface.getcoord(::AbstractGeometryTrait, geom::AbstractGeometry, i) =
@@ -67,6 +63,7 @@ GeoInterface.ncoord(t::AbstractGeometryTrait, geom::PreparedGeometry) =
 GeoInterface.getcoord(t::AbstractGeometryTrait, geom::PreparedGeometry, i) =
     GeoInterface.getcoord(t, geom.ownedby, i)
 
+# FIXME this doesn't work for 3d geoms, Z is missing
 function GeoInterface.extent(::AbstractGeometryTrait, geom::AbstractGeometry)
     # minx, miny, maxx, maxy = getExtent(geom)
     env = envelope(geom)

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -27,7 +27,7 @@ const LG = LibGEOS
     plot(pt)
 
     pt = LibGEOS.Point(1, 2)
-    @atest GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
+    @test GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
     @test GeoInterface.geomtrait(pt) == PointTrait()
     @test GeoInterface.testgeometry(pt)
 

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -23,7 +23,7 @@ const LG = LibGEOS
     @test GeoInterface.getcoord(pt, 3) ≈ 3.0
     @test GeoInterface.testgeometry(pt)
     # This doesn't return the Z extent
-    @tehst_broken GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y=(2.0, 2.0), Z=(3.0, 3.0))
+    @test_broken GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y=(2.0, 2.0), Z=(3.0, 3.0))
     plot(pt)
 
     pt = LibGEOS.Point(1, 2)

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -4,6 +4,8 @@ const LG = LibGEOS
 
 @testset "Geo interface" begin
     pt = LibGEOS.Point(1.0, 2.0)
+    @test GeoInterface.x(pt) == 1.0
+    @test GeoInterface.y(pt) == 2.0
     @test GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
     @test GeoInterface.geomtrait(pt) == PointTrait()
     @test GeoInterface.ncoord(pt) == 2
@@ -12,8 +14,20 @@ const LG = LibGEOS
     @test GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y = (2.0, 2.0))
     plot(pt)
 
+    pt = LibGEOS.Point(1.0, 2.0, 3.0)
+    @test GeoInterface.x(pt) == 1.0
+    @test GeoInterface.y(pt) == 2.0
+    @test GeoInterface.z(pt) == 3.0
+    @test GeoInterface.coordinates(pt) ≈ [1, 2, 3] atol = 1e-5
+    @test GeoInterface.ncoord(pt) == 3
+    @test GeoInterface.getcoord(pt, 3) ≈ 3.0
+    @test GeoInterface.testgeometry(pt)
+    # This doesn't return the Z extent
+    @tehst_broken GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y=(2.0, 2.0), Z=(3.0, 3.0))
+    plot(pt)
+
     pt = LibGEOS.Point(1, 2)
-    @test GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
+    @atest GeoInterface.coordinates(pt) ≈ [1, 2] atol = 1e-5
     @test GeoInterface.geomtrait(pt) == PointTrait()
     @test GeoInterface.testgeometry(pt)
 


### PR DESCRIPTION
The current x, y and z implementation is broken, this PR just deletes it because the fallbacks are not.

It actually tests that these function work now as well.