### PR TITLE
rerun gen/generator.jl for GEOS 3.12

### DIFF
--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.0"
+julia_version = "1.10.0-beta2"
 manifest_format = "2.0"
 project_hash = "c207a7c5032a4b9a7a881d57cf2ab43f0327ec83"
 
@@ -27,32 +27,34 @@ version = "3.3.6"
 
 [[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "0b40886a23b65c23e6c2a4169e14f2743327a2b2"
+git-tree-sha1 = "d78c2973d7a752be377fe173bc9ff2dc2d9c3ed6"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.16.1"
+version = "0.17.6"
 
 [[deps.Clang_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll", "libLLVM_jll"]
-git-tree-sha1 = "0dfffba1b32bb3e30cb0372bfe666a5ddffe37fb"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
+git-tree-sha1 = "1b72866ec1a54e7e4593f7a137c892bb365570f4"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "13.0.1+3"
+version = "15.0.7+8"
 
 [[deps.CommonMark]]
-deps = ["Crayons", "JSON", "URIs"]
-git-tree-sha1 = "4cd7063c9bdebdbd55ede1af70f3c2f48fab4215"
+deps = ["Crayons", "JSON", "PrecompileTools", "URIs"]
+git-tree-sha1 = "532c4185d3c9037c0237546d817858b23cf9e071"
 uuid = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
-version = "0.8.6"
+version = "0.8.12"
 
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "5856d3031cdb1f3b2b6340dfdc66b6d9a149a374"
+deps = ["UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.2.0"
+version = "4.9.0"
 
-[[deps.CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+    [deps.Compat.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -61,9 +63,9 @@ version = "4.1.1"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
+git-tree-sha1 = "3dbd312d370723b6bb43ba9d02fc36abade4518d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.13"
+version = "0.18.15"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -78,42 +80,47 @@ version = "1.6.0"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.GEOS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f4c0cafb093b62d5a5d8447a9b2306555385c0d9"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e143352a8a1b1c7236d05bc9e0982420099c46af"
 uuid = "d604d12d-fa86-5845-992e-78dc15976526"
-version = "3.11.0+0"
+version = "3.12.0+0"
+
+[[deps.Glob]]
+git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.3.1"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.4.1"
+version = "1.5.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.3"
+version = "0.21.4"
 
 [[deps.JuliaFormatter]]
-deps = ["CSTParser", "CommonMark", "DataStructures", "Pkg", "Tokenize"]
-git-tree-sha1 = "bc360182bf55b82cf15efb1cbc1b3607d05e1648"
+deps = ["CSTParser", "CommonMark", "DataStructures", "Glob", "Pkg", "PrecompileTools", "Tokenize"]
+git-tree-sha1 = "680fb31c8b8e2cf482f48e55d8fa01ccc4469e04"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "1.0.9"
+version = "1.0.35"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "8.0.1+1"
 
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
@@ -122,23 +129,19 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
+git-tree-sha1 = "9ee1618cbf5240e6d4e0371d6f24065083f60c48"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.9"
+version = "0.5.11"
 
 [[deps.Markdown]]
 deps = ["Base64"]
@@ -147,45 +150,46 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.0+0"
+version = "2.28.2+1"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.2.1"
+version = "2023.1.10"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[deps.OpenBLAS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
-uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
-
 [[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "2e73fe17cac3c62ad1aebe70d44c963c3cfdc3e3"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.6.2"
 
 [[deps.Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "3d5bf43e3e8b412656404ed9466f1dcbf7c50269"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.4.0"
+version = "2.7.2"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+version = "1.10.0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -196,7 +200,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.SHA]]
@@ -212,7 +216,7 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -220,14 +224,14 @@ uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
 [[deps.Tokenize]]
-git-tree-sha1 = "2b3af135d85d7e70b863540160208fa612e736b9"
+git-tree-sha1 = "90538bf898832b6ebd900fa40f223e695970e3a5"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.24"
+version = "0.5.25"
 
 [[deps.URIs]]
-git-tree-sha1 = "e59ecc5a41b000fa94423a578d29290c7266fc10"
+git-tree-sha1 = "b7a5e99f24892b6824a954199a45e9ffcc1c70f0"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.4.0"
+version = "1.5.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -239,24 +243,19 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+3"
+version = "1.2.13+1"
 
 [[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
-version = "13.0.1+3"
-
-[[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
+version = "15.0.7+8"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"

--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -18,8 +18,7 @@ export GeometryCollection,
     Polygon,
     STRtree
 
-export 
-    area,
+export area,
     boundary,
     buffer,
     bufferWithStyle,

--- a/src/generated/libgeos_api.jl
+++ b/src/generated/libgeos_api.jl
@@ -70,7 +70,9 @@ const GEOSTransformXYCallback = Ptr{Cvoid}
 const GEOSInterruptCallback = Cvoid
 
 function GEOS_interruptRegisterCallback(cb)
-    @ccall libgeos.GEOS_interruptRegisterCallback(cb::Ptr{Cvoid})::Ptr{Cvoid}
+    @ccall libgeos.GEOS_interruptRegisterCallback(
+        cb::Ptr{GEOSInterruptCallback},
+    )::Ptr{GEOSInterruptCallback}
 end
 
 function GEOS_interruptRequest()
@@ -542,6 +544,14 @@ function GEOSGeom_createCollection_r(handle, type, geoms, ngeoms)
     )::Ptr{GEOSGeometry}
 end
 
+function GEOSGeom_releaseCollection_r(handle, collection, ngeoms)
+    @ccall libgeos.GEOSGeom_releaseCollection_r(
+        handle::GEOSContextHandle_t,
+        collection::Ptr{GEOSGeometry},
+        ngeoms::Ptr{Cuint},
+    )::Ptr{Ptr{GEOSGeometry}}
+end
+
 function GEOSGeom_createEmptyCollection_r(handle, type)
     @ccall libgeos.GEOSGeom_createEmptyCollection_r(
         handle::GEOSContextHandle_t,
@@ -571,6 +581,31 @@ function GEOSGeom_destroy_r(handle, g)
         handle::GEOSContextHandle_t,
         g::Ptr{GEOSGeometry},
     )::Cvoid
+end
+
+function GEOSCoverageUnion_r(handle, g)
+    @ccall libgeos.GEOSCoverageUnion_r(
+        handle::GEOSContextHandle_t,
+        g::Ptr{GEOSGeometry},
+    )::Ptr{GEOSGeometry}
+end
+
+function GEOSCoverageIsValid_r(extHandle, input, gapWidth, output)
+    @ccall libgeos.GEOSCoverageIsValid_r(
+        extHandle::GEOSContextHandle_t,
+        input::Ptr{GEOSGeometry},
+        gapWidth::Cdouble,
+        output::Ptr{Ptr{GEOSGeometry}},
+    )::Cint
+end
+
+function GEOSCoverageSimplifyVW_r(extHandle, input, tolerance, preserveBoundary)
+    @ccall libgeos.GEOSCoverageSimplifyVW_r(
+        extHandle::GEOSContextHandle_t,
+        input::Ptr{GEOSGeometry},
+        tolerance::Cdouble,
+        preserveBoundary::Cint,
+    )::Ptr{GEOSGeometry}
 end
 
 function GEOSEnvelope_r(handle, g)
@@ -606,6 +641,15 @@ end
 
 function GEOSConcaveHull_r(handle, g, ratio, allowHoles)
     @ccall libgeos.GEOSConcaveHull_r(
+        handle::GEOSContextHandle_t,
+        g::Ptr{GEOSGeometry},
+        ratio::Cdouble,
+        allowHoles::Cuint,
+    )::Ptr{GEOSGeometry}
+end
+
+function GEOSConcaveHullByLength_r(handle, g, ratio, allowHoles)
+    @ccall libgeos.GEOSConcaveHullByLength_r(
         handle::GEOSContextHandle_t,
         g::Ptr{GEOSGeometry},
         ratio::Cdouble,
@@ -761,8 +805,8 @@ function GEOSUnaryUnionPrec_r(handle, g, gridSize)
     )::Ptr{GEOSGeometry}
 end
 
-function GEOSCoverageUnion_r(handle, g)
-    @ccall libgeos.GEOSCoverageUnion_r(
+function GEOSDisjointSubsetUnion_r(handle, g)
+    @ccall libgeos.GEOSDisjointSubsetUnion_r(
         handle::GEOSContextHandle_t,
         g::Ptr{GEOSGeometry},
     )::Ptr{GEOSGeometry}
@@ -864,6 +908,15 @@ function GEOSLineMergeDirected_r(handle, g)
     )::Ptr{GEOSGeometry}
 end
 
+function GEOSLineSubstring_r(handle, g, start_fraction, end_fdraction)
+    @ccall libgeos.GEOSLineSubstring_r(
+        handle::GEOSContextHandle_t,
+        g::Ptr{GEOSGeometry},
+        start_fraction::Cdouble,
+        end_fdraction::Cdouble,
+    )::Ptr{GEOSGeometry}
+end
+
 function GEOSReverse_r(handle, g)
     @ccall libgeos.GEOSReverse_r(
         handle::GEOSContextHandle_t,
@@ -927,13 +980,13 @@ function GEOSConstrainedDelaunayTriangulation_r(handle, g)
     )::Ptr{GEOSGeometry}
 end
 
-function GEOSVoronoiDiagram_r(extHandle, g, env, tolerance, onlyEdges)
+function GEOSVoronoiDiagram_r(extHandle, g, env, tolerance, flags)
     @ccall libgeos.GEOSVoronoiDiagram_r(
         extHandle::GEOSContextHandle_t,
         g::Ptr{GEOSGeometry},
         env::Ptr{GEOSGeometry},
         tolerance::Cdouble,
-        onlyEdges::Cint,
+        flags::Cint,
     )::Ptr{GEOSGeometry}
 end
 
@@ -1038,6 +1091,14 @@ function GEOSEqualsExact_r(handle, g1, g2, tolerance)
     )::Cchar
 end
 
+function GEOSEqualsIdentical_r(handle, g1, g2)
+    @ccall libgeos.GEOSEqualsIdentical_r(
+        handle::GEOSContextHandle_t,
+        g1::Ptr{GEOSGeometry},
+        g2::Ptr{GEOSGeometry},
+    )::Cchar
+end
+
 function GEOSCovers_r(handle, g1, g2)
     @ccall libgeos.GEOSCovers_r(
         handle::GEOSContextHandle_t,
@@ -1073,6 +1134,15 @@ function GEOSPreparedContains_r(handle, pg1, g2)
         handle::GEOSContextHandle_t,
         pg1::Ptr{GEOSPreparedGeometry},
         g2::Ptr{GEOSGeometry},
+    )::Cchar
+end
+
+function GEOSPreparedContainsXY_r(handle, pg1, x, y)
+    @ccall libgeos.GEOSPreparedContainsXY_r(
+        handle::GEOSContextHandle_t,
+        pg1::Ptr{GEOSPreparedGeometry},
+        x::Cdouble,
+        y::Cdouble,
     )::Cchar
 end
 
@@ -1121,6 +1191,15 @@ function GEOSPreparedIntersects_r(handle, pg1, g2)
         handle::GEOSContextHandle_t,
         pg1::Ptr{GEOSPreparedGeometry},
         g2::Ptr{GEOSGeometry},
+    )::Cchar
+end
+
+function GEOSPreparedIntersectsXY_r(handle, pg1, x, y)
+    @ccall libgeos.GEOSPreparedIntersectsXY_r(
+        handle::GEOSContextHandle_t,
+        pg1::Ptr{GEOSPreparedGeometry},
+        x::Cdouble,
+        y::Cdouble,
     )::Cchar
 end
 
@@ -1179,6 +1258,13 @@ function GEOSSTRtree_create_r(handle, nodeCapacity)
         handle::GEOSContextHandle_t,
         nodeCapacity::Csize_t,
     )::Ptr{GEOSSTRtree}
+end
+
+function GEOSSTRtree_build_r(handle, tree)
+    @ccall libgeos.GEOSSTRtree_build_r(
+        handle::GEOSContextHandle_t,
+        tree::Ptr{GEOSSTRtree},
+    )::Cint
 end
 
 function GEOSSTRtree_insert_r(handle, tree, g, item)
@@ -1265,6 +1351,10 @@ end
 
 function GEOSHasZ_r(handle, g)
     @ccall libgeos.GEOSHasZ_r(handle::GEOSContextHandle_t, g::Ptr{GEOSGeometry})::Cchar
+end
+
+function GEOSHasM_r(handle, g)
+    @ccall libgeos.GEOSHasM_r(handle::GEOSContextHandle_t, g::Ptr{GEOSGeometry})::Cchar
 end
 
 function GEOSisClosed_r(handle, g)
@@ -1472,6 +1562,14 @@ function GEOSNormalize_r(handle, g)
     @ccall libgeos.GEOSNormalize_r(handle::GEOSContextHandle_t, g::Ptr{GEOSGeometry})::Cint
 end
 
+function GEOSOrientPolygons_r(handle, g, exteriorCW)
+    @ccall libgeos.GEOSOrientPolygons_r(
+        handle::GEOSContextHandle_t,
+        g::Ptr{GEOSGeometry},
+        exteriorCW::Cint,
+    )::Cint
+end
+
 @cenum GEOSPrecisionRules::UInt32 begin
     GEOS_PREC_VALID_OUTPUT = 0
     GEOS_PREC_NO_TOPO = 1
@@ -1529,6 +1627,14 @@ function GEOSGeomGetZ_r(handle, g, z)
         handle::GEOSContextHandle_t,
         g::Ptr{GEOSGeometry},
         z::Ptr{Cdouble},
+    )::Cint
+end
+
+function GEOSGeomGetM_r(handle, g, m)
+    @ccall libgeos.GEOSGeomGetM_r(
+        handle::GEOSContextHandle_t,
+        g::Ptr{GEOSGeometry},
+        m::Ptr{Cdouble},
     )::Cint
 end
 
@@ -2292,6 +2398,13 @@ function GEOSGeom_createCollection(type, geoms, ngeoms)
     )::Ptr{GEOSGeometry}
 end
 
+function GEOSGeom_releaseCollection(collection, ngeoms)
+    @ccall libgeos.GEOSGeom_releaseCollection(
+        collection::Ptr{GEOSGeometry},
+        ngeoms::Ptr{Cuint},
+    )::Ptr{Ptr{GEOSGeometry}}
+end
+
 function GEOSGeom_createEmptyCollection(type)
     @ccall libgeos.GEOSGeom_createEmptyCollection(type::Cint)::Ptr{GEOSGeometry}
 end
@@ -2359,6 +2472,10 @@ end
 
 function GEOSGeomGetZ(g, z)
     @ccall libgeos.GEOSGeomGetZ(g::Ptr{GEOSGeometry}, z::Ptr{Cdouble})::Cint
+end
+
+function GEOSGeomGetM(g, m)
+    @ccall libgeos.GEOSGeomGetM(g::Ptr{GEOSGeometry}, m::Ptr{Cdouble})::Cint
 end
 
 function GEOSGetInteriorRingN(g, n)
@@ -2435,6 +2552,10 @@ function GEOSHasZ(g)
     @ccall libgeos.GEOSHasZ(g::Ptr{GEOSGeometry})::Cchar
 end
 
+function GEOSHasM(g)
+    @ccall libgeos.GEOSHasM(g::Ptr{GEOSGeometry})::Cchar
+end
+
 function GEOSisClosed(g)
     @ccall libgeos.GEOSisClosed(g::Ptr{GEOSGeometry})::Cchar
 end
@@ -2449,6 +2570,10 @@ end
 
 function GEOSNormalize(g)
     @ccall libgeos.GEOSNormalize(g::Ptr{GEOSGeometry})::Cint
+end
+
+function GEOSOrientPolygons(g, exteriorCW)
+    @ccall libgeos.GEOSOrientPolygons(g::Ptr{GEOSGeometry}, exteriorCW::Cint)::Cint
 end
 
 function GEOSisSimple(g)
@@ -2690,8 +2815,8 @@ function GEOSUnaryUnionPrec(g, gridSize)
     )::Ptr{GEOSGeometry}
 end
 
-function GEOSCoverageUnion(g)
-    @ccall libgeos.GEOSCoverageUnion(g::Ptr{GEOSGeometry})::Ptr{GEOSGeometry}
+function GEOSDisjointSubsetUnion(g)
+    @ccall libgeos.GEOSDisjointSubsetUnion(g::Ptr{GEOSGeometry})::Ptr{GEOSGeometry}
 end
 
 function GEOSClipByRect(g, xmin, ymin, xmax, ymax)
@@ -2791,6 +2916,26 @@ function GEOSOffsetCurve(g, width, quadsegs, joinStyle, mitreLimit)
     )::Ptr{GEOSGeometry}
 end
 
+function GEOSCoverageUnion(g)
+    @ccall libgeos.GEOSCoverageUnion(g::Ptr{GEOSGeometry})::Ptr{GEOSGeometry}
+end
+
+function GEOSCoverageIsValid(input, gapWidth, invalidEdges)
+    @ccall libgeos.GEOSCoverageIsValid(
+        input::Ptr{GEOSGeometry},
+        gapWidth::Cdouble,
+        invalidEdges::Ptr{Ptr{GEOSGeometry}},
+    )::Cint
+end
+
+function GEOSCoverageSimplifyVW(input, tolerance, preserveBoundary)
+    @ccall libgeos.GEOSCoverageSimplifyVW(
+        input::Ptr{GEOSGeometry},
+        tolerance::Cdouble,
+        preserveBoundary::Cint,
+    )::Ptr{GEOSGeometry}
+end
+
 function GEOSEnvelope(g)
     @ccall libgeos.GEOSEnvelope(g::Ptr{GEOSGeometry})::Ptr{GEOSGeometry}
 end
@@ -2808,6 +2953,23 @@ function GEOSConcaveHull(g, ratio, allowHoles)
         g::Ptr{GEOSGeometry},
         ratio::Cdouble,
         allowHoles::Cuint,
+    )::Ptr{GEOSGeometry}
+end
+
+function GEOSConcaveHullByLength(g, length, allowHoles)
+    @ccall libgeos.GEOSConcaveHullByLength(
+        g::Ptr{GEOSGeometry},
+        length::Cdouble,
+        allowHoles::Cuint,
+    )::Ptr{GEOSGeometry}
+end
+
+function GEOSConcaveHullOfPolygons(g, lengthRatio, isTight, isHolesAllowed)
+    @ccall libgeos.GEOSConcaveHullOfPolygons(
+        g::Ptr{GEOSGeometry},
+        lengthRatio::Cdouble,
+        isTight::Cuint,
+        isHolesAllowed::Cuint,
     )::Ptr{GEOSGeometry}
 end
 
@@ -2830,15 +2992,6 @@ function GEOSPolygonHullSimplifyMode(g, isOuter, parameterMode, parameter)
         isOuter::Cuint,
         parameterMode::Cuint,
         parameter::Cdouble,
-    )::Ptr{GEOSGeometry}
-end
-
-function GEOSConcaveHullOfPolygons(g, lengthRatio, isTight, isHolesAllowed)
-    @ccall libgeos.GEOSConcaveHullOfPolygons(
-        g::Ptr{GEOSGeometry},
-        lengthRatio::Cdouble,
-        isTight::Cuint,
-        isHolesAllowed::Cuint,
     )::Ptr{GEOSGeometry}
 end
 
@@ -2895,12 +3048,17 @@ function GEOSConstrainedDelaunayTriangulation(g)
     )::Ptr{GEOSGeometry}
 end
 
-function GEOSVoronoiDiagram(g, env, tolerance, onlyEdges)
+@cenum GEOSVoronoiFlags::UInt32 begin
+    GEOS_VORONOI_ONLY_EDGES = 1
+    GEOS_VORONOI_PRESERVE_ORDER = 2
+end
+
+function GEOSVoronoiDiagram(g, env, tolerance, flags)
     @ccall libgeos.GEOSVoronoiDiagram(
         g::Ptr{GEOSGeometry},
         env::Ptr{GEOSGeometry},
         tolerance::Cdouble,
-        onlyEdges::Cint,
+        flags::Cint,
     )::Ptr{GEOSGeometry}
 end
 
@@ -2952,6 +3110,14 @@ end
 
 function GEOSLineMergeDirected(g)
     @ccall libgeos.GEOSLineMergeDirected(g::Ptr{GEOSGeometry})::Ptr{GEOSGeometry}
+end
+
+function GEOSLineSubstring(g, start_fraction, end_fraction)
+    @ccall libgeos.GEOSLineSubstring(
+        g::Ptr{GEOSGeometry},
+        start_fraction::Cdouble,
+        end_fraction::Cdouble,
+    )::Ptr{GEOSGeometry}
 end
 
 function GEOSReverse(g)
@@ -3054,6 +3220,10 @@ function GEOSEqualsExact(g1, g2, tolerance)
     )::Cchar
 end
 
+function GEOSEqualsIdentical(g1, g2)
+    @ccall libgeos.GEOSEqualsIdentical(g1::Ptr{GEOSGeometry}, g2::Ptr{GEOSGeometry})::Cchar
+end
+
 function GEOSRelatePattern(g1, g2, pat)
     @ccall libgeos.GEOSRelatePattern(
         g1::Ptr{GEOSGeometry},
@@ -3099,6 +3269,14 @@ function GEOSPreparedContains(pg1, g2)
     )::Cchar
 end
 
+function GEOSPreparedContainsXY(pg1, x, y)
+    @ccall libgeos.GEOSPreparedContainsXY(
+        pg1::Ptr{GEOSPreparedGeometry},
+        x::Cdouble,
+        y::Cdouble,
+    )::Cchar
+end
+
 function GEOSPreparedContainsProperly(pg1, g2)
     @ccall libgeos.GEOSPreparedContainsProperly(
         pg1::Ptr{GEOSPreparedGeometry},
@@ -3138,6 +3316,14 @@ function GEOSPreparedIntersects(pg1, g2)
     @ccall libgeos.GEOSPreparedIntersects(
         pg1::Ptr{GEOSPreparedGeometry},
         g2::Ptr{GEOSGeometry},
+    )::Cchar
+end
+
+function GEOSPreparedIntersectsXY(pg1, x, y)
+    @ccall libgeos.GEOSPreparedIntersectsXY(
+        pg1::Ptr{GEOSPreparedGeometry},
+        x::Cdouble,
+        y::Cdouble,
     )::Cchar
 end
 
@@ -3187,6 +3373,10 @@ end
 
 function GEOSSTRtree_create(nodeCapacity)
     @ccall libgeos.GEOSSTRtree_create(nodeCapacity::Csize_t)::Ptr{GEOSSTRtree}
+end
+
+function GEOSSTRtree_build(tree)
+    @ccall libgeos.GEOSSTRtree_build(tree::Ptr{GEOSSTRtree})::Cint
 end
 
 function GEOSSTRtree_insert(tree, g, item)
@@ -3632,21 +3822,21 @@ end
 
 const GEOS_VERSION_MAJOR = 3
 
-const GEOS_VERSION_MINOR = 11
+const GEOS_VERSION_MINOR = 12
 
 const GEOS_VERSION_PATCH = 0
 
-const GEOS_VERSION = "3.11.0"
+const GEOS_VERSION = "3.12.0"
 
 const GEOS_JTS_PORT = "1.18.0"
 
 const GEOS_CAPI_VERSION_MAJOR = 1
 
-const GEOS_CAPI_VERSION_MINOR = 17
+const GEOS_CAPI_VERSION_MINOR = 18
 
 const GEOS_CAPI_VERSION_PATCH = 0
 
-const GEOS_CAPI_VERSION = "3.11.0-CAPI-1.17.0"
+const GEOS_CAPI_VERSION = "3.12.0-CAPI-1.18.0"
 
 const GEOS_CAPI_FIRST_INTERFACE = GEOS_CAPI_VERSION_MAJOR
 

--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -70,49 +70,97 @@ function GeoInterface.extent(::AbstractGeometryTrait, geom::AbstractGeometry)
     return Extent(X = (getXMin(env), getXMax(env)), Y = (getYMin(env), getYMax(env)))
 end
 
-GI.convert(::Type{Point}, ::PointTrait, geom::Point; context=nothing) = geom
-function GI.convert(::Type{Point}, ::PointTrait, geom; context=get_global_context())
+GI.convert(::Type{Point}, ::PointTrait, geom::Point; context = nothing) = geom
+function GI.convert(::Type{Point}, ::PointTrait, geom; context = get_global_context())
     if GI.is3d(geom)
         return Point(GI.x(geom), GI.y(geom), GI.z(geom), context)
     else
         return Point(GI.x(geom), GI.y(geom), context)
     end
 end
-GI.convert(::Type{MultiPoint}, ::MultiPointTrait, geom::MultiPoint; context=nothing) = geom
-function GI.convert(::Type{MultiPoint}, t::MultiPointTrait, geom; context=get_global_context())
+GI.convert(::Type{MultiPoint}, ::MultiPointTrait, geom::MultiPoint; context = nothing) =
+    geom
+function GI.convert(
+    ::Type{MultiPoint},
+    t::MultiPointTrait,
+    geom;
+    context = get_global_context(),
+)
     points = Point[GI.convert(Point, PointTrait(), p) for p in GI.getpoint(t, geom)]
     return MultiPoint(points, context)
 end
-GI.convert(::Type{LineString}, ::LineStringTrait, geom::LineString; context=nothing) = geom
-function GI.convert(::Type{LineString}, ::LineStringTrait, geom; context=get_global_context())
+GI.convert(::Type{LineString}, ::LineStringTrait, geom::LineString; context = nothing) =
+    geom
+function GI.convert(
+    ::Type{LineString},
+    ::LineStringTrait,
+    geom;
+    context = get_global_context(),
+)
     # Faster to make a CoordSeq directly here
     seq = _geom_to_coord_seq(geom, context)
     return LineString(createLineString(seq, context), context)
 end
-GI.convert(::Type{LinearRing}, ::LinearRingTrait, geom::LinearRing; context=nothing) = geom
-function GI.convert(::Type{LinearRing}, ::LinearRingTrait, geom; context=get_global_context())
+GI.convert(::Type{LinearRing}, ::LinearRingTrait, geom::LinearRing; context = nothing) =
+    geom
+function GI.convert(
+    ::Type{LinearRing},
+    ::LinearRingTrait,
+    geom;
+    context = get_global_context(),
+)
     # Faster to make a CoordSeq directly here
     seq = _geom_to_coord_seq(geom, context)
     return LinearRing(createLinearRing(seq, context), context)
 end
-GI.convert(::Type{MultiLineString}, ::MultiLineStringTrait, geom::MultiLineString; context=nothing) = geom
-function GI.convert(::Type{MultiLineString}, ::MultiLineStringTrait, geom; context=get_global_context())
-    linestrings = LineString[GI.convert(LineString, LineStringTrait(), g; context) for g in getgeom(geom)]
+GI.convert(
+    ::Type{MultiLineString},
+    ::MultiLineStringTrait,
+    geom::MultiLineString;
+    context = nothing,
+) = geom
+function GI.convert(
+    ::Type{MultiLineString},
+    ::MultiLineStringTrait,
+    geom;
+    context = get_global_context(),
+)
+    linestrings = LineString[
+        GI.convert(LineString, LineStringTrait(), g; context) for g in getgeom(geom)
+    ]
     return MultiLineString(linestrings)
 end
-GI.convert(::Type{Polygon}, ::PolygonTrait, geom::Polygon; context=nothing) = geom
-function GI.convert(::Type{Polygon}, ::PolygonTrait, geom; context=get_global_context())
+GI.convert(::Type{Polygon}, ::PolygonTrait, geom::Polygon; context = nothing) = geom
+function GI.convert(::Type{Polygon}, ::PolygonTrait, geom; context = get_global_context())
     exterior = GI.convert(LinearRing, GI.LinearRingTrait(), GI.getexterior(geom); context)
-    holes = LinearRing[GI.convert(LinearRing, GI.LinearRingTrait(), g; context) for g in GI.gethole(geom)]
+    holes = LinearRing[
+        GI.convert(LinearRing, GI.LinearRingTrait(), g; context) for g in GI.gethole(geom)
+    ]
     return Polygon(exterior, holes)
 end
-GI.convert(::Type{MultiPolygon}, ::MultiPolygonTrait, geom::MultiPolygon; context=nothing) = geom
-function GI.convert(::Type{MultiPolygon}, ::MultiPolygonTrait, geom; context=get_global_context())
-    polygons = Polygon[GI.convert(Polygon, PolygonTrait(), g; context) for g in GI.getgeom(geom)]
+GI.convert(
+    ::Type{MultiPolygon},
+    ::MultiPolygonTrait,
+    geom::MultiPolygon;
+    context = nothing,
+) = geom
+function GI.convert(
+    ::Type{MultiPolygon},
+    ::MultiPolygonTrait,
+    geom;
+    context = get_global_context(),
+)
+    polygons =
+        Polygon[GI.convert(Polygon, PolygonTrait(), g; context) for g in GI.getgeom(geom)]
     return MultiPolygon(polygons)
 end
 
-function GI.convert(t::Type{<:AbstractGeometry}, ::AbstractGeometryTrait, geom; context=nothing)
+function GI.convert(
+    t::Type{<:AbstractGeometry},
+    ::AbstractGeometryTrait,
+    geom;
+    context = nothing,
+)
     error(
         "Cannot convert an object of $(of(geom)) with the $(of()) trait to a $t (yet). Please report an issue.",
     )
@@ -237,9 +285,22 @@ bufferWithStyle(obj, dist::Real; kw...) = bufferWithStyle(to_geos(obj), dist; kw
 
 # 1 geom methods
 for f in (
-    :area, :geomLength, :envelope, :minimumRotatedRectangle, :convexhull, :boundary,
-    :unaryUnion, :pointOnSurface, :centroid, :node, :simplify, :topologyPreserveSimplify, :uniquePoints,
-    :delaunayTriangulationEdges, :delaunayTriangulation, :constrainedDelaunayTriangulation,
+    :area,
+    :geomLength,
+    :envelope,
+    :minimumRotatedRectangle,
+    :convexhull,
+    :boundary,
+    :unaryUnion,
+    :pointOnSurface,
+    :centroid,
+    :node,
+    :simplify,
+    :topologyPreserveSimplify,
+    :uniquePoints,
+    :delaunayTriangulationEdges,
+    :delaunayTriangulation,
+    :constrainedDelaunayTriangulation,
 )
     # We convert the geometry to a GEOS geometry and forward it to the geos method
     @eval $f(geom, args...; kw...) = $f(to_geos(geom), args...; kw...)
@@ -249,12 +310,32 @@ end
 
 # 2 geom methods
 for f in (
-    :project, :projectNormalized, :intersection, :difference, :symmetricDifference, :union, :sharedPaths,
-    :snap, :distance, :hausdorffdistance, :nearestPoints, :disjoint, :touches, :intersects, :crosses,
-    :within, :contains, :overlaps, :equalsexact, :covers, :coveredby, :equals,
+    :project,
+    :projectNormalized,
+    :intersection,
+    :difference,
+    :symmetricDifference,
+    :union,
+    :sharedPaths,
+    :snap,
+    :distance,
+    :hausdorffdistance,
+    :nearestPoints,
+    :disjoint,
+    :touches,
+    :intersects,
+    :crosses,
+    :within,
+    :contains,
+    :overlaps,
+    :equalsexact,
+    :covers,
+    :coveredby,
+    :equals,
 )
     # We convert the geometries to GEOS geometries and forward them to the geos method
-    @eval $f(geom1, geom2, args...; kw...) = $f(to_geos(geom1), to_geos(geom2), args...; kw...)
+    @eval $f(geom1, geom2, args...; kw...) =
+        $f(to_geos(geom1), to_geos(geom2), args...; kw...)
     @eval $f(geom1::AbstractGeometry, geom2::AbstractGeometry, args...; kw...) =
         throw(MethodError($f, (geom1, geom2, args...)))
 end

--- a/src/geos_functions.jl
+++ b/src/geos_functions.jl
@@ -1,4 +1,8 @@
-function _readgeom(wktstring::String, wktreader::WKTReader, context::GEOSContext = get_global_context())
+function _readgeom(
+    wktstring::String,
+    wktreader::WKTReader,
+    context::GEOSContext = get_global_context(),
+)
     result = GEOSWKTReader_read_r(context, wktreader, wktstring)
     if result == C_NULL
         error("LibGEOS: Error in GEOSWKTReader_read_r while reading $wktstring")
@@ -13,12 +17,7 @@ function _readgeom(
     wkbreader::WKBReader,
     context::GEOSContext = get_global_context(),
 )
-    result = GEOSWKBReader_read_r(
-        context,
-        wkbreader,
-        wkbbuffer,
-        length(wkbbuffer),
-    )
+    result = GEOSWKBReader_read_r(context, wkbreader, wkbbuffer, length(wkbbuffer))
     if result == C_NULL
         error("LibGEOS: Error in GEOSWKBReader_read_r")
     end
@@ -27,21 +26,35 @@ end
 _readgeom(wkbbuffer::Vector{Cuchar}, context::GEOSContext = get_global_context()) =
     _readgeom(wkbbuffer, WKBReader(context), context)
 
-readgeom(wktstring::String, wktreader::WKTReader, context::GEOSContext = get_global_context()) =
-    geomFromGEOS(_readgeom(wktstring, wktreader, context), context)
+readgeom(
+    wktstring::String,
+    wktreader::WKTReader,
+    context::GEOSContext = get_global_context(),
+) = geomFromGEOS(_readgeom(wktstring, wktreader, context), context)
 readgeom(wktstring::String, context::GEOSContext = get_global_context()) =
     readgeom(wktstring, WKTReader(context), context)
 
-readgeom(wkbbuffer::Vector{Cuchar}, wkbreader::WKBReader, context::GEOSContext = get_global_context()) =
-    geomFromGEOS(_readgeom(wkbbuffer, wkbreader, context), context)
+readgeom(
+    wkbbuffer::Vector{Cuchar},
+    wkbreader::WKBReader,
+    context::GEOSContext = get_global_context(),
+) = geomFromGEOS(_readgeom(wkbbuffer, wkbreader, context), context)
 readgeom(wkbbuffer::Vector{Cuchar}, context::GEOSContext = get_global_context()) =
     readgeom(wkbbuffer, WKBReader(context), context)
 
-function writegeom(obj::Geometry, wktwriter::WKTWriter, context::GEOSContext = get_context(obj))
+function writegeom(
+    obj::Geometry,
+    wktwriter::WKTWriter,
+    context::GEOSContext = get_context(obj),
+)
     GEOSWKTWriter_write_r(context, wktwriter, obj)
 end
 
-function writegeom(obj::Geometry, wkbwriter::WKBWriter, context::GEOSContext = get_context(obj))
+function writegeom(
+    obj::Geometry,
+    wkbwriter::WKBWriter,
+    context::GEOSContext = get_context(obj),
+)
     wkbsize = Ref{Csize_t}()
     result = GEOSWKBWriter_write_r(context, wkbwriter, obj, wkbsize)
     unsafe_wrap(Array, result, wkbsize[], own = true)
@@ -61,7 +74,11 @@ writegeom(obj::PreparedGeometry, context::GEOSContext = get_context(obj)) =
 
 Create a Coordinate sequence with ``size'' coordinates of ``dims'' dimensions (Return NULL on exception)
 """
-function createCoordSeq(size::Integer, context::GEOSContext = get_global_context(); ndim::Integer = 2)
+function createCoordSeq(
+    size::Integer,
+    context::GEOSContext = get_global_context();
+    ndim::Integer = 2,
+)
     @assert ndim >= 2
     result = GEOSCoordSeq_create_r(context, size, ndim)
     if result == C_NULL
@@ -88,7 +105,12 @@ function destroyCoordSeq(ptr::GEOSCoordSeq, context::GEOSContext = get_global_co
 end
 
 # Set ordinate values in a Coordinate Sequence (Return 0 on exception)
-function setX!(ptr::GEOSCoordSeq, i::Integer, value::Real, context::GEOSContext = get_global_context())
+function setX!(
+    ptr::GEOSCoordSeq,
+    i::Integer,
+    value::Real,
+    context::GEOSContext = get_global_context(),
+)
     if !(0 < i <= getSize(ptr, context))
         error(
             "LibGEOS: i=$i is out of bounds for CoordSeq with size=$(getSize(ptr, context))",
@@ -101,7 +123,12 @@ function setX!(ptr::GEOSCoordSeq, i::Integer, value::Real, context::GEOSContext 
     result
 end
 
-function setY!(ptr::GEOSCoordSeq, i::Integer, value::Real, context::GEOSContext = get_global_context())
+function setY!(
+    ptr::GEOSCoordSeq,
+    i::Integer,
+    value::Real,
+    context::GEOSContext = get_global_context(),
+)
     if !(0 < i <= getSize(ptr, context))
         error(
             "LibGEOS: i=$i is out of bounds for CoordSeq with size=$(getSize(ptr, context))",
@@ -114,7 +141,12 @@ function setY!(ptr::GEOSCoordSeq, i::Integer, value::Real, context::GEOSContext 
     result
 end
 
-function setZ!(ptr::GEOSCoordSeq, i::Integer, value::Real, context::GEOSContext = get_global_context())
+function setZ!(
+    ptr::GEOSCoordSeq,
+    i::Integer,
+    value::Real,
+    context::GEOSContext = get_global_context(),
+)
     if !(0 < i <= getSize(ptr, context))
         error(
             "LibGEOS: i=$i is out of bounds for CoordSeq with size=$(getSize(ptr, context))",
@@ -185,7 +217,12 @@ end
 
 Create a createCoordSeq of a single 3D coordinate
 """
-function createCoordSeq(x::Real, y::Real, z::Real, context::GEOSContext = get_global_context())
+function createCoordSeq(
+    x::Real,
+    y::Real,
+    z::Real,
+    context::GEOSContext = get_global_context(),
+)
     coordinates = createCoordSeq(1, context, ndim = 3)
     setX!(coordinates, 1, x, context)
     setY!(coordinates, 1, y, context)
@@ -198,7 +235,10 @@ end
 
 Create a createCoordSeq of a single N dimensional coordinate
 """
-function createCoordSeq(coords::Vector{Float64}, context::GEOSContext = get_global_context())
+function createCoordSeq(
+    coords::Vector{Float64},
+    context::GEOSContext = get_global_context(),
+)
     ndim = length(coords)
     @assert ndim >= 2
     coordinates = createCoordSeq(1, context, ndim = ndim)
@@ -210,7 +250,10 @@ end
 
 Create a createCoordSeq of a multiple N dimensional coordinate
 """
-function createCoordSeq(coords::Vector{Vector{Float64}}, context::GEOSContext = get_global_context())
+function createCoordSeq(
+    coords::Vector{Vector{Float64}},
+    context::GEOSContext = get_global_context(),
+)
     ncoords = length(coords)
     @assert ncoords > 0
     ndim = length(coords[1])
@@ -316,7 +359,11 @@ function getCoordinates!(out::Vector{Float64}, ptr::GEOSCoordSeq, i::Integer, co
     out
 end
 
-function getCoordinates(ptr::GEOSCoordSeq, i::Integer, context::GEOSContext = get_global_context())
+function getCoordinates(
+    ptr::GEOSCoordSeq,
+    i::Integer,
+    context::GEOSContext = get_global_context(),
+)
     ndim = getDimensions(ptr, context)
     out = Array{Float64}(undef, ndim)
     getCoordinates!(out, ptr, i, context)
@@ -363,10 +410,17 @@ function interpolate(line::LineString, dist::Real, context::GEOSContext = get_co
     Point(result, context)
 end
 
-projectNormalized(line::LineString, point::Point, context::GEOSContext = get_context(line)) =
-    GEOSProjectNormalized_r(context, line, point)
+projectNormalized(
+    line::LineString,
+    point::Point,
+    context::GEOSContext = get_context(line),
+) = GEOSProjectNormalized_r(context, line, point)
 
-function interpolateNormalized(line::LineString, dist::Real, context::GEOSContext = get_context(line))
+function interpolateNormalized(
+    line::LineString,
+    dist::Real,
+    context::GEOSContext = get_context(line),
+)
     result = GEOSInterpolateNormalized_r(context, line, dist)
     if result == C_NULL
         error("LibGEOS: Error in GEOSInterpolateNormalized")
@@ -382,8 +436,12 @@ end
 # The user can control the accuracy of the curve approximation by specifying the number of linear segments with which to approximate a curve.
 
 # Always returns a polygon. The negative or zero-distance buffer of lines and points is always an empty Polygon.
-buffer(obj::Geometry, dist::Real, quadsegs::Integer = 8, context::GEOSContext = get_context(obj)) =
-    geomFromGEOS(GEOSBuffer_r(context, obj, dist, Int32(quadsegs)), context)
+buffer(
+    obj::Geometry,
+    dist::Real,
+    quadsegs::Integer = 8,
+    context::GEOSContext = get_context(obj),
+) = geomFromGEOS(GEOSBuffer_r(context, obj, dist, Int32(quadsegs)), context)
 
 bufferWithStyle(
     obj::Geometry,
@@ -393,15 +451,18 @@ bufferWithStyle(
     joinStyle::GEOSBufJoinStyles = GEOSBUF_JOIN_ROUND,
     mitreLimit::Real = 5.0,
     context::GEOSContext = get_context(obj),
-) = geomFromGEOS(GEOSBufferWithStyle_r(
+) = geomFromGEOS(
+    GEOSBufferWithStyle_r(
+        context,
+        obj,
+        dist,
+        Int32(quadsegs),
+        Int32(endCapStyle),
+        Int32(joinStyle),
+        mitreLimit,
+    ),
     context,
-    obj,
-    dist,
-    Int32(quadsegs),
-    Int32(endCapStyle),
-    Int32(joinStyle),
-    mitreLimit,
-), context)
+)
 
 # GEOSBufferParams_create
 # GEOSBufferParams_destroy
@@ -441,8 +502,10 @@ function createLinearRing(ptr::GEOSCoordSeq, context::GEOSContext = get_global_c
     end
     result
 end
-createLinearRing(coords::Vector{Vector{Float64}}, context::GEOSContext = get_global_context()) =
-    GEOSGeom_createLinearRing_r(context, createCoordSeq(coords, context))
+createLinearRing(
+    coords::Vector{Vector{Float64}},
+    context::GEOSContext = get_global_context(),
+) = GEOSGeom_createLinearRing_r(context, createCoordSeq(coords, context))
 
 function createLineString(ptr::GEOSCoordSeq, context::GEOSContext = get_global_context())
     result = GEOSGeom_createLineString_r(context, ptr)
@@ -451,8 +514,10 @@ function createLineString(ptr::GEOSCoordSeq, context::GEOSContext = get_global_c
     end
     result
 end
-createLineString(coords::Vector{Vector{Float64}}, context::GEOSContext = get_global_context()) =
-    GEOSGeom_createLineString_r(context, createCoordSeq(coords, context))
+createLineString(
+    coords::Vector{Vector{Float64}},
+    context::GEOSContext = get_global_context(),
+) = GEOSGeom_createLineString_r(context, createCoordSeq(coords, context))
 
 # Second argument is an array of GEOSGeometry* objects.
 # The caller remains owner of the array, but pointed-to
@@ -469,23 +534,27 @@ function createPolygon(
     result
 end
 # convenience function to create polygon without holes
-createPolygon(shell::Union{LinearRing,GEOSGeom}, context::GEOSContext = get_global_context()) =
-    createPolygon(shell, GEOSGeom[], context)
+createPolygon(
+    shell::Union{LinearRing,GEOSGeom},
+    context::GEOSContext = get_global_context(),
+) = createPolygon(shell, GEOSGeom[], context)
 
 function createCollection(
     geomtype::GEOSGeomTypes,
     geoms::AbstractVector,
     context::GEOSContext = get_global_context(),
 )
-    result =
-        GEOSGeom_createCollection_r(context, geomtype, geoms, length(geoms))
+    result = GEOSGeom_createCollection_r(context, geomtype, geoms, length(geoms))
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeom_createCollection")
     end
     result
 end
 
-function createEmptyCollection(geomtype::GEOSGeomTypes, context::GEOSContext = get_global_context())
+function createEmptyCollection(
+    geomtype::GEOSGeomTypes,
+    context::GEOSContext = get_global_context(),
+)
     result = GEOSGeom_createEmptyCollection_r(context, geomtype)
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeom_createEmptyCollection")
@@ -501,7 +570,10 @@ function createEmptyPolygon(context::GEOSContext = get_global_context())::Polygo
     Polygon(result, context)
 end
 
-function reverse(obj::Geometry, context::GEOSContext = get_context(obj))::LibGEOS.AbstractGeometry
+function reverse(
+    obj::Geometry,
+    context::GEOSContext = get_context(obj),
+)::LibGEOS.AbstractGeometry
     result = GEOSReverse_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSReverse_r")
@@ -509,7 +581,10 @@ function reverse(obj::Geometry, context::GEOSContext = get_context(obj))::LibGEO
     geomFromGEOS(result, context)
 end
 
-function makeValid(obj::Geometry, context::GEOSContext = get_context(obj))::LibGEOS.AbstractGeometry
+function makeValid(
+    obj::Geometry,
+    context::GEOSContext = get_context(obj),
+)::LibGEOS.AbstractGeometry
     result = GEOSMakeValid_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSMakeValid_r")
@@ -519,7 +594,10 @@ end
 
 # Memory management
 # cloneGeom result needs to be wrapped in Geometry type
-function cloneGeom(ptr::Union{Geometry,GEOSGeom}, context::GEOSContext = get_global_context())
+function cloneGeom(
+    ptr::Union{Geometry,GEOSGeom},
+    context::GEOSContext = get_global_context(),
+)
     result = GEOSGeom_clone_r(context, ptr)
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeom_clone")
@@ -571,7 +649,11 @@ function minimumRotatedRectangle(obj::Geometry, context::GEOSContext = get_conte
 end
 
 
-function intersection(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function intersection(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSIntersection_r(context, obj1, obj2)
     if result == C_NULL
         error("LibGEOS: Error in GEOSIntersection")
@@ -591,7 +673,11 @@ function convexhull(obj::Geometry, context::GEOSContext = get_context(obj))
     geomFromGEOS(result, context)
 end
 
-function difference(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function difference(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSDifference_r(context, obj1, obj2)
     if result == C_NULL
         error("LibGEOS: Error in GEOSDifference")
@@ -599,7 +685,11 @@ function difference(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_c
     geomFromGEOS(result, context)
 end
 
-function symmetricDifference(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function symmetricDifference(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSSymDifference_r(context, obj1, obj2)
     if result == C_NULL
         error("LibGEOS: Error in GEOSSymDifference")
@@ -674,7 +764,11 @@ function lineMerge(obj::Geometry, context::GEOSContext = get_context(obj))
     geomFromGEOS(result, context)
 end
 
-function maximumInscribedCircle(obj::Geometry, tolerance, context::GEOSContext = get_context(obj))
+function maximumInscribedCircle(
+    obj::Geometry,
+    tolerance,
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSMaximumInscribedCircle_r(context, obj, tolerance)
     if result == C_NULL
         error("LibGEOS: Error in GEOSMaximumInscribedCircle")
@@ -698,7 +792,11 @@ function simplify(obj::Geometry, tol::Real, context::GEOSContext = get_context(o
     geomFromGEOS(result, context)
 end
 
-function topologyPreserveSimplify(obj::Geometry, tol::Real, context::GEOSContext = get_context(obj))
+function topologyPreserveSimplify(
+    obj::Geometry,
+    tol::Real,
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSTopologyPreserveSimplify_r(context, obj, tol)
     if result == C_NULL
         error("LibGEOS: Error in GEOSTopologyPreserveSimplify")
@@ -723,7 +821,11 @@ end
 #  - second element is a MULTILINESTRING containing shared paths
 #    having the _opposite_ direction on the two inputs
 # (Returns NULL on exception)
-function sharedPaths(obj1::LineString, obj2::LineString, context::GEOSContext = get_context(obj1))
+function sharedPaths(
+    obj1::LineString,
+    obj2::LineString,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSSharedPaths_r(context, obj1, obj2)
     if result == C_NULL
         error("LibGEOS: Error in GEOSSharedPaths")
@@ -733,7 +835,12 @@ end
 
 # Snap first geometry on to second with given tolerance
 # (Returns a newly allocated geometry, or NULL on exception)
-function snap(obj1::Geometry, obj2::Geometry, tol::Real, context::GEOSContext = get_context(obj1))
+function snap(
+    obj1::Geometry,
+    obj2::Geometry,
+    tol::Real,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSSnap_r(context, obj1, obj2, tol)
     if result == C_NULL
         error("LibGEOS: Error in GEOSSnap")
@@ -770,7 +877,10 @@ function delaunayTriangulationEdges(
     delaunayTriangulation(obj, tol, true, context)
 end
 
-function constrainedDelaunayTriangulation(obj::Geometry, context::GEOSContext = get_context(obj))
+function constrainedDelaunayTriangulation(
+    obj::Geometry,
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSConstrainedDelaunayTriangulation_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSConstrainedDelaunayTriangulation")
@@ -797,7 +907,11 @@ function touches(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_cont
     result != 0x00
 end
 
-function intersects(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function intersects(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSIntersects_r(context, obj1, obj2)
     if result == 0x02
         error("LibGEOS: Error in GEOSIntersects")
@@ -848,7 +962,12 @@ function equals(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_conte
     result != 0x00
 end
 
-function equalsexact(obj1::Geometry, obj2::Geometry, tol::Real, context::GEOSContext = get_context(obj1))
+function equalsexact(
+    obj1::Geometry,
+    obj2::Geometry,
+    tol::Real,
+    context::GEOSContext = get_context(obj1),
+)
     result = GEOSEqualsExact_r(context, obj1, obj2, tol)
     if result == 0x02
         error("LibGEOS: Error in GEOSEqualsExact")
@@ -885,17 +1004,23 @@ function prepareGeom(obj::Geometry, context::GEOSContext = get_context(obj))
     PreparedGeometry(result, obj)
 end
 
-function destroyPreparedGeom(obj::PreparedGeometry, context::GEOSContext = get_global_context())
+function destroyPreparedGeom(
+    obj::PreparedGeometry,
+    context::GEOSContext = get_global_context(),
+)
     GEOSPreparedGeom_destroy_r(context, obj)
 end
 
-Base.contains(obj1::PreparedGeometry, obj2::Geometry, context::GEOSContext = get_context(obj1)) =
-    contains(obj1, obj2, context)
+Base.contains(
+    obj1::PreparedGeometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+) = contains(obj1, obj2, context)
 
 function contains(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedContains_r(context, obj1, obj2)
     if result == 0x02
@@ -907,7 +1032,7 @@ end
 function containsproperly(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedContainsProperly_r(context, obj1, obj2)
     if result == 0x02
@@ -919,7 +1044,7 @@ end
 function coveredby(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedCoveredBy_r(context, obj1, obj2)
     if result == 0x02
@@ -931,7 +1056,7 @@ end
 function covers(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedCovers_r(context, obj1, obj2)
     if result == 0x02
@@ -943,7 +1068,7 @@ end
 function crosses(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedCrosses_r(context, obj1, obj2)
     if result == 0x02
@@ -955,7 +1080,7 @@ end
 function disjoint(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedDisjoint_r(context, obj1, obj2)
     if result == 0x02
@@ -967,7 +1092,7 @@ end
 function intersects(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedIntersects_r(context, obj1, obj2)
     if result == 0x02
@@ -979,7 +1104,7 @@ end
 function overlaps(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedOverlaps_r(context, obj1, obj2)
     if result == 0x02
@@ -991,7 +1116,7 @@ end
 function touches(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedTouches_r(context, obj1, obj2)
     if result == 0x02
@@ -1003,7 +1128,7 @@ end
 function within(
     obj1::PreparedGeometry,
     obj2::Geometry,
-    context::GEOSContext = get_context(obj1)
+    context::GEOSContext = get_context(obj1),
 )
     result = GEOSPreparedWithin_r(context, obj1, obj2)
     if result == 0x02
@@ -1117,7 +1242,10 @@ end
 # end
 
 # Return -1 on exception
-function geomTypeId(obj::Union{Geometry, Ptr{Cvoid}}, context::GEOSContext = get_global_context())
+function geomTypeId(
+    obj::Union{Geometry,Ptr{Cvoid}},
+    context::GEOSContext = get_global_context(),
+)
     result = GEOSGeomTypeId_r(context, obj)
     if result == -1
         error("LibGEOS: Error in GEOSGeomTypeId")
@@ -1134,7 +1262,8 @@ function getSRID(obj::Geometry, context::GEOSContext = get_context(obj))
     result
 end
 
-setSRID(obj::Geometry, context::GEOSContext = get_context(obj)) = GEOSSetSRID_r(context, obj)
+setSRID(obj::Geometry, context::GEOSContext = get_context(obj)) =
+    GEOSSetSRID_r(context, obj)
 
 # May be called on all geometries in GEOS 3.x, returns -1 on error and 1
 # for non-multi geometries. Older GEOS versions only accept
@@ -1210,7 +1339,10 @@ function numInteriorRings(obj::Polygon, context::GEOSContext = get_context(obj))
 end
 
 # Call only on LINESTRING (returns -1 on exception)
-function numPoints(obj::Union{LineString,LinearRing}, context::GEOSContext = get_context(obj))
+function numPoints(
+    obj::Union{LineString,LinearRing},
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSGeomGetNumPoints_r(context, obj)
     if result == -1
         error("LibGEOS: Error in GEOSGeomGetNumPoints")
@@ -1281,7 +1413,10 @@ function numCoordinates(obj::Geometry, context::GEOSContext = get_context(obj))
 end
 
 # Geometry must be a LineString, LinearRing or Point (Return NULL on exception)
-function getCoordSeq(obj::Union{LineString, LinearRing, Point}, context::GEOSContext = get_context(obj))
+function getCoordSeq(
+    obj::Union{LineString,LinearRing,Point},
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSGeom_getCoordSeq_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeom_getCoordSeq")
@@ -1379,7 +1514,11 @@ end
 # end
 
 # Call only on LINESTRING, and must be freed by caller (Returns NULL on exception)
-function getPoint(obj::Union{LineString,LinearRing}, n::Integer, context::GEOSContext = get_context(obj))
+function getPoint(
+    obj::Union{LineString,LinearRing},
+    n::Integer,
+    context::GEOSContext = get_context(obj),
+)
     if !(0 < n <= numPoints(obj, context))
         error(
             "LibGEOS: n=$n is out of bounds for LineString with numPoints=$(numPoints(obj, context))",
@@ -1393,7 +1532,10 @@ function getPoint(obj::Union{LineString,LinearRing}, n::Integer, context::GEOSCo
 end
 
 # Call only on LINESTRING, and must be freed by caller (Returns NULL on exception)
-function startPoint(obj::Union{LineString,LinearRing}, context::GEOSContext = get_context(obj))
+function startPoint(
+    obj::Union{LineString,LinearRing},
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSGeomGetStartPoint_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeomGetStartPoint")
@@ -1402,7 +1544,10 @@ function startPoint(obj::Union{LineString,LinearRing}, context::GEOSContext = ge
 end
 
 # Call only on LINESTRING, and must be freed by caller (Returns NULL on exception)
-function endPoint(obj::Union{LineString,LinearRing}, context::GEOSContext = get_context(obj))
+function endPoint(
+    obj::Union{LineString,LinearRing},
+    context::GEOSContext = get_context(obj),
+)
     result = GEOSGeomGetEndPoint_r(context, obj)
     if result == C_NULL
         error("LibGEOS: Error in GEOSGeomGetEndPoint")
@@ -1443,7 +1588,11 @@ function distance(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_con
     out[]
 end
 
-function hausdorffdistance(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function hausdorffdistance(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     out = Ref{Float64}()
     # Return 0 on exception, 1 otherwise
     result = GEOSHausdorffDistance_r(context, obj1, obj2, out)
@@ -1471,23 +1620,35 @@ end
 # Returns the closest points of the two geometries.
 # The first point comes from g1 geometry and the second point comes from g2.
 # Return 0 on exception, the closest points of the two geometries otherwise.
-function nearestPoints(obj1::Geometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function nearestPoints(
+    obj1::Geometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     points = GEOSNearestPoints_r(context, obj1, obj2)
     if points == C_NULL
         return Point[]
     else
-        return Point[Point(getCoordinates(points, 1, context), context),
-                     Point(getCoordinates(points, 2, context), context)]
+        return Point[
+            Point(getCoordinates(points, 1, context), context),
+            Point(getCoordinates(points, 2, context), context),
+        ]
     end
 end
 
-function nearestPoints(obj1::PreparedGeometry, obj2::Geometry, context::GEOSContext = get_context(obj1))
+function nearestPoints(
+    obj1::PreparedGeometry,
+    obj2::Geometry,
+    context::GEOSContext = get_context(obj1),
+)
     points = GEOSPreparedNearestPoints_r(context, obj1, obj2)
     if points == C_NULL
         return Point[]
     else
-        return Point[Point(getCoordinates(points, 1, context), context),
-                     Point(getCoordinates(points, 2, context), context)]
+        return Point[
+            Point(getCoordinates(points, 1, context), context),
+            Point(getCoordinates(points, 2, context), context),
+        ]
     end
 end
 

--- a/src/geos_types.jl
+++ b/src/geos_types.jl
@@ -46,16 +46,15 @@ mutable struct MultiPoint <: AbstractGeometry
     context::GEOSContext
     # create a multipoint from a pointer - only makes sense if it is a pointer to a multipoint
     # or to a point, otherwise error
-    function MultiPoint(obj::Union{Point,MultiPoint,GEOSGeom}, context::GEOSContext = get_global_context())
+    function MultiPoint(
+        obj::Union{Point,MultiPoint,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         multipoint = if id == GEOS_MULTIPOINT
             new(cloneGeom(obj, context), context)
         elseif id == GEOS_POINT
-            new(createCollection(GEOS_MULTIPOINT,
-                                 [cloneGeom(obj, context)],
-                                 context),
-                context
-               )
+            new(createCollection(GEOS_MULTIPOINT, [cloneGeom(obj, context)], context), context)
         else
             open_issue_if_conversion_makes_sense(MultiPoint, id)
         end
@@ -63,28 +62,30 @@ mutable struct MultiPoint <: AbstractGeometry
         multipoint
     end
     # create a multipoint frome a vector of vector coordinates
-    MultiPoint(multipoint::Vector{Vector{Float64}}, context::GEOSContext = get_global_context()) =
-        MultiPoint(
-            createCollection(
-                GEOS_MULTIPOINT,
-                GEOSGeom[createPoint(coords, context) for coords in multipoint],
-                context),
-            context)
+    MultiPoint(
+        multipoint::Vector{Vector{Float64}},
+        context::GEOSContext = get_global_context(),
+    ) = MultiPoint(
+        createCollection(
+            GEOS_MULTIPOINT,
+            GEOSGeom[createPoint(coords, context) for coords in multipoint],
+            context,
+        ),
+        context,
+    )
     # create a multipoint from a list of points
     MultiPoint(points::Vector{LibGEOS.Point}, context::GEOSContext = get_context(points)) =
-        MultiPoint(
-            createCollection(
-                GEOS_MULTIPOINT,
-                points,
-                context),
-            context)
+        MultiPoint(createCollection(GEOS_MULTIPOINT, points, context), context)
 end
 
 mutable struct LineString <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a linestring from a linestring pointer, otherwise error
-    function LineString(obj::Union{LineString,GEOSGeom}, context::GEOSContext = get_global_context())
+    function LineString(
+        obj::Union{LineString,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         line = if id == GEOS_LINESTRING
             new(cloneGeom(obj, context), context)
@@ -95,7 +96,10 @@ mutable struct LineString <: AbstractGeometry
         line
     end
     # create a linestring from a vector of points
-    function LineString(coords::Vector{Vector{Float64}}, context::GEOSContext = get_global_context())
+    function LineString(
+        coords::Vector{Vector{Float64}},
+        context::GEOSContext = get_global_context(),
+    )
         line = new(createLineString(coords, context), context)
         finalizer(destroyGeom, line)
         line
@@ -111,14 +115,18 @@ mutable struct MultiLineString <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a multiline string from a multilinestring or a linestring pointer, else error
-    function MultiLineString(obj::Union{LineString,MultiLineString,GEOSGeom}, context::GEOSContext = get_global_context())
+    function MultiLineString(
+        obj::Union{LineString,MultiLineString,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         multiline = if id == GEOS_MULTILINESTRING
             new(cloneGeom(obj, context), context)
         elseif id == GEOS_LINESTRING
-            new(createCollection(GEOS_MULTILINESTRING,
-                                 [cloneGeom(obj, context)],
-                                 context), context)
+            new(
+                createCollection(GEOS_MULTILINESTRING, [cloneGeom(obj, context)], context),
+                context,
+            )
         else
             open_issue_if_conversion_makes_sense(MultiLineString, id)
         end
@@ -126,27 +134,38 @@ mutable struct MultiLineString <: AbstractGeometry
         multiline
     end
     # create a multilinestring from a list of linestring coordinates
-    MultiLineString(multiline::Vector{Vector{Vector{Float64}}},context::GEOSContext = get_global_context()) =
-        MultiLineString(
-            createCollection(
-                GEOS_MULTILINESTRING,
-                GEOSGeom[createLineString(coords, context) for coords in multiline],
-                context),
-            context)
-    MultiLineString(multiline::Vector{LineString}, context::GEOSContext = get_global_context()) =
-        MultiLineString(
-            createCollection(
-                GEOS_MULTILINESTRING,
-                GEOSGeom[ls.ptr for ls in multiline],
-                context),
-            context)
+    MultiLineString(
+        multiline::Vector{Vector{Vector{Float64}}},
+        context::GEOSContext = get_global_context(),
+    ) = MultiLineString(
+        createCollection(
+            GEOS_MULTILINESTRING,
+            GEOSGeom[createLineString(coords, context) for coords in multiline],
+            context,
+        ),
+        context,
+    )
+    MultiLineString(
+        multiline::Vector{LineString},
+        context::GEOSContext = get_global_context(),
+    ) = MultiLineString(
+        createCollection(
+            GEOS_MULTILINESTRING,
+            GEOSGeom[ls.ptr for ls in multiline],
+            context,
+        ),
+        context,
+    )
 end
 
 mutable struct LinearRing <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a linear ring from a linear ring pointer, otherwise error
-    function LinearRing(obj::Union{LinearRing,GEOSGeom}, context::GEOSContext = get_global_context())
+    function LinearRing(
+        obj::Union{LinearRing,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         ring = if id == GEOS_LINEARRING
             new(cloneGeom(obj, context), context)
@@ -158,7 +177,10 @@ mutable struct LinearRing <: AbstractGeometry
     end
     # create linear ring from a list of coordinates -
     # first and last coordinates must be the same
-    function LinearRing(coords::Vector{Vector{Float64}}, context::GEOSContext = get_global_context())
+    function LinearRing(
+        coords::Vector{Vector{Float64}},
+        context::GEOSContext = get_global_context(),
+    )
         ring = new(createLinearRing(coords, context), context)
         finalizer(destroyGeom, ring)
         ring
@@ -170,7 +192,10 @@ mutable struct Polygon <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create polygon using GEOSGeom pointer - only makes sense if pointer points to a polygon or a linear ring to start with.
-    function Polygon(obj::Union{Polygon,LinearRing,GEOSGeom}, context::GEOSContext = get_global_context())
+    function Polygon(
+        obj::Union{Polygon,LinearRing,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         polygon = if id == GEOS_POLYGON
             new(cloneGeom(obj, context), context)
@@ -184,7 +209,10 @@ mutable struct Polygon <: AbstractGeometry
     end
     # using vector of coordinates in following form:
     # [[exterior], [hole1], [hole2], ...] where exterior and holeN are coordinates where the first and last point are the same
-    function Polygon(coords::Vector{Vector{Vector{Float64}}}, context::GEOSContext = get_global_context())
+    function Polygon(
+        coords::Vector{Vector{Vector{Float64}}},
+        context::GEOSContext = get_global_context(),
+    )
         exterior = createLinearRing(coords[1], context)
         interiors = GEOSGeom[createLinearRing(lr, context) for lr in coords[2:end]]
         polygon = new(createPolygon(exterior, interiors, context), context)
@@ -192,29 +220,29 @@ mutable struct Polygon <: AbstractGeometry
         polygon
     end
     # using multiple linear rings to form polygon with holes - exterior linear ring will be polygon boundary and list of interior linear rings will form holes
-    Polygon(exterior::LinearRing, holes::Vector{LinearRing}, context::GEOSContext = get_context(exterior)) =
-        Polygon(
-            createPolygon(exterior,
-                          holes,
-                          context),
-            context)
+    Polygon(
+        exterior::LinearRing,
+        holes::Vector{LinearRing},
+        context::GEOSContext = get_context(exterior),
+    ) = Polygon(createPolygon(exterior, holes, context), context)
 end
 
 mutable struct MultiPolygon <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create multipolygon using a multipolygon or polygon pointer, else error
-    function MultiPolygon(obj::Union{Polygon,MultiPolygon,GEOSGeom}, context::GEOSContext = get_global_context())
+    function MultiPolygon(
+        obj::Union{Polygon,MultiPolygon,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         multipolygon = if id == GEOS_MULTIPOLYGON
             new(cloneGeom(obj, context), context)
         elseif id == GEOS_POLYGON
-            new(createCollection(
-                    GEOS_MULTIPOLYGON,
-                    [cloneGeom(obj, context)],
-                    context),
-                context
-               )
+            new(
+                createCollection(GEOS_MULTIPOLYGON, [cloneGeom(obj, context)], context),
+                context,
+            )
         else
             open_issue_if_conversion_makes_sense(MultiPolygon, id)
         end
@@ -224,33 +252,36 @@ mutable struct MultiPolygon <: AbstractGeometry
 
     # create multipolygon from list of Polygon objects
     MultiPolygon(polygons::Vector{Polygon}, context::GEOSContext = get_context(polygons)) =
-        MultiPolygon(
-            createCollection(
-                GEOS_MULTIPOLYGON,
-                polygons,
-                context),
-            context)
+        MultiPolygon(createCollection(GEOS_MULTIPOLYGON, polygons, context), context)
 
     # create multipolygon using list of polygon coordinates - note that each polygon can have holes as explained above in Polygon comments
-    MultiPolygon(multipolygon::Vector{Vector{Vector{Vector{Float64}}}}, context::GEOSContext = get_global_context()) =
-        MultiPolygon(
-            createCollection(
-                GEOS_MULTIPOLYGON,
-                GEOSGeom[
-                    createPolygon(
-                        createLinearRing(coords[1], context),
-                        GEOSGeom[createLinearRing(c, context) for c in coords[2:end]],
-                        context)
-                    for coords in multipolygon],
-                context),
-            context)
+    MultiPolygon(
+        multipolygon::Vector{Vector{Vector{Vector{Float64}}}},
+        context::GEOSContext = get_global_context(),
+    ) = MultiPolygon(
+        createCollection(
+            GEOS_MULTIPOLYGON,
+            GEOSGeom[
+                createPolygon(
+                    createLinearRing(coords[1], context),
+                    GEOSGeom[createLinearRing(c, context) for c in coords[2:end]],
+                    context,
+                ) for coords in multipolygon
+            ],
+            context,
+        ),
+        context,
+    )
 end
 
 mutable struct GeometryCollection <: AbstractGeometry
     ptr::GEOSGeom
     context::GEOSContext
     # create a geometric collection from a pointer to a geometric collection, else error
-    function GeometryCollection(obj::Union{GeometryCollection,GEOSGeom}, context::GEOSContext = get_global_context())
+    function GeometryCollection(
+        obj::Union{GeometryCollection,GEOSGeom},
+        context::GEOSContext = get_global_context(),
+    )
         id = LibGEOS.geomTypeId(obj, context)
         geometrycollection = if id == GEOS_GEOMETRYCOLLECTION
             new(cloneGeom(obj, context), context)
@@ -261,20 +292,24 @@ mutable struct GeometryCollection <: AbstractGeometry
         geometrycollection
     end
     # create a geometric collection from a list of pointers to geometric objects
-    GeometryCollection(collection::AbstractVector, context::GEOSContext = get_global_context()) =
-        GeometryCollection(
-            createCollection(
-                GEOS_GEOMETRYCOLLECTION,
-                collection,
-                context),
-            context)
-    GeometryCollection(collection::Vector{<:AbstractGeometry}, context::GEOSContext = get_global_context()) =
-        GeometryCollection(
-            createCollection(
-                GEOS_GEOMETRYCOLLECTION,
-                GEOSGeom[geom.ptr for geom in collection],
-                context),
-            context)
+    GeometryCollection(
+        collection::AbstractVector,
+        context::GEOSContext = get_global_context(),
+    ) = GeometryCollection(
+        createCollection(GEOS_GEOMETRYCOLLECTION, collection, context),
+        context,
+    )
+    GeometryCollection(
+        collection::Vector{<:AbstractGeometry},
+        context::GEOSContext = get_global_context(),
+    ) = GeometryCollection(
+        createCollection(
+            GEOS_GEOMETRYCOLLECTION,
+            GEOSGeom[geom.ptr for geom in collection],
+            context,
+        ),
+        context,
+    )
 end
 
 const Geometry = Union{
@@ -293,7 +328,7 @@ const Geometry = Union{
 
 Create a deep copy of obj, optionally also moving it to a new context.
 """
-function clone(obj::Geometry, context=get_context(obj))
+function clone(obj::Geometry, context = get_context(obj))
     G = typeof(obj)
     # Note that all Geometry constructors
     # implicitly clone the pointer, in the following line
@@ -328,7 +363,7 @@ const geomtypes = [
     GeometryCollection,
 ]
 
-const HasCoordSeq = Union{LineString, LinearRing, Point}
+const HasCoordSeq = Union{LineString,LinearRing,Point}
 """
 
     coordinates!(out::Vector{Float64}, geo::$HasCoordSeq, i::Integer)
@@ -336,13 +371,18 @@ const HasCoordSeq = Union{LineString, LinearRing, Point}
 
 Copy the coordinates of the ith point of geo into `out`.
 """
-function coordinates!(out, geo::HasCoordSeq, i::Integer, ctx::GEOSContext=get_context(geo))
+function coordinates!(
+    out,
+    geo::HasCoordSeq,
+    i::Integer,
+    ctx::GEOSContext = get_context(geo),
+)
     GC.@preserve out geo begin
         seq = GEOSGeom_getCoordSeq_r(ctx, geo)::Ptr
         getCoordinates!(out, seq, i, ctx)
     end
 end
-function coordinates!(out, geo::Point, ctx::GEOSContext=get_context(geo))
+function coordinates!(out, geo::Point, ctx::GEOSContext = get_context(geo))
     coordinates!(out, geo, 1, ctx)
 end
 
@@ -354,8 +394,8 @@ function has_coord_seq(::HasCoordSeq)
 end
 
 Base.@kwdef struct IsApprox
-    atol::Float64=0.0
-    rtol::Float64=sqrt(eps(Float64))
+    atol::Float64 = 0.0
+    rtol::Float64 = sqrt(eps(Float64))
 end
 
 function Base.:(==)(geo1::AbstractGeometry, geo2::AbstractGeometry)::Bool
@@ -365,9 +405,14 @@ function Base.isequal(geo1::AbstractGeometry, geo2::AbstractGeometry)::Bool
     compare(isequal, geo1, geo2)
 end
 function Base.isapprox(geo1::AbstractGeometry, geo2::AbstractGeometry; kw...)::Bool
-    compare(IsApprox(;kw...), geo1, geo2)
+    compare(IsApprox(; kw...), geo1, geo2)
 end
-function compare(cmp, geo1::AbstractGeometry, geo2::AbstractGeometry, ctx=get_context(geo1))::Bool
+function compare(
+    cmp,
+    geo1::AbstractGeometry,
+    geo2::AbstractGeometry,
+    ctx = get_context(geo1),
+)::Bool
     (typeof(geo1) === typeof(geo2)) || return false
     if (geo1 === geo2) && (cmp === isequal)
         return true
@@ -378,7 +423,7 @@ function compare(cmp, geo1::AbstractGeometry, geo2::AbstractGeometry, ctx=get_co
         ng1 = ngeom(geo1)
         ng2 = ngeom(geo2)
         ng1 == ng2 || return false
-        for i in 1:ng1
+        for i = 1:ng1
             compare(cmp, getgeom(geo1, i), getgeom(geo2, i), ctx) || return false
         end
     end
@@ -398,7 +443,7 @@ function compare_coord_seqs(cmp, geo1, geo2, ctx)
     np1 == np2 || return false
     coords1 = Vector{Float64}(undef, ncoords1)
     coords2 = Vector{Float64}(undef, ncoords1)
-    for i in 1:np1
+    for i = 1:np1
         coordinates!(coords1, geo1, i, ctx)
         coordinates!(coords2, geo2, i, ctx)
         cmp(coords1, coords2) || return false
@@ -423,16 +468,16 @@ function compare_coord_seqs(cmp::IsApprox, geo1, geo2, ctx)
     s1 = 0.0
     s2 = 0.0
     s12 = 0.0
-    for i in 1:np1
+    for i = 1:np1
         coordinates!(coords1, geo1, i, ctx)
         coordinates!(coords2, geo2, i, ctx)
         if ncoords1 == 2
-            x1,y1 = coords1
-            x2,y2 = coords2
+            x1, y1 = coords1
+            x2, y2 = coords2
             s12 += (x1 - x2)^2 + (y1 - y2)^2
         else
-            x1,y1,z1 = coords1
-            x2,y2,z2 = coords2
+            x1, y1, z1 = coords1
+            x2, y2, z2 = coords2
             s12 += (x1 - x2)^2 + (y1 - y2)^2 + (z1 - z2)^2
         end
         s1 += sum(abs2, coords1)
@@ -441,22 +486,22 @@ function compare_coord_seqs(cmp::IsApprox, geo1, geo2, ctx)
     return sqrt(s12) <= cmp.atol + cmp.rtol * sqrt(max(s1, s2))
 end
 
-typesalt(::Type{GeometryCollection} ) = 0xd1fd7c6403c36e5b
-typesalt(::Type{PreparedGeometry}   ) = 0xbc1a26fe2f5b7537
-typesalt(::Type{LineString}         ) = 0x712352fe219fca15
-typesalt(::Type{LinearRing}         ) = 0xac7644fd36955ef1
-typesalt(::Type{MultiLineString}    ) = 0x85aff0a53a2f2a32
-typesalt(::Type{MultiPoint}         ) = 0x6213e67dbfd3b570
-typesalt(::Type{MultiPolygon}       ) = 0xff2f957b4cdb5832
-typesalt(::Type{Point}              ) = 0x4b5c101d3843160e
-typesalt(::Type{Polygon}            ) = 0xa5c895d62ef56723
+typesalt(::Type{GeometryCollection}) = 0xd1fd7c6403c36e5b
+typesalt(::Type{PreparedGeometry}) = 0xbc1a26fe2f5b7537
+typesalt(::Type{LineString}) = 0x712352fe219fca15
+typesalt(::Type{LinearRing}) = 0xac7644fd36955ef1
+typesalt(::Type{MultiLineString}) = 0x85aff0a53a2f2a32
+typesalt(::Type{MultiPoint}) = 0x6213e67dbfd3b570
+typesalt(::Type{MultiPolygon}) = 0xff2f957b4cdb5832
+typesalt(::Type{Point}) = 0x4b5c101d3843160e
+typesalt(::Type{Polygon}) = 0xa5c895d62ef56723
 
 function Base.hash(geo::AbstractGeometry, h::UInt)::UInt
     h = hash(typesalt(typeof(geo)), h)
     if has_coord_seq(geo)
         return hash_coord_seq(geo, h)
     else
-        for i in 1:ngeom(geo)
+        for i = 1:ngeom(geo)
             h = hash(getgeom(geo, i), h)
         end
     end
@@ -469,7 +514,7 @@ function hash_coord_seq(geo::HasCoordSeq, h::UInt)::UInt
     end
     buf = Vector{Float64}(undef, nc)
     ctx = get_context(geo)
-    for i in 1:npoints(geo)
+    for i = 1:npoints(geo)
         coordinates!(buf, geo, i, ctx)
         h = hash(buf, h)
     end
@@ -497,7 +542,10 @@ const GEOMTYPE = Dict{GEOSGeomTypes,Symbol}(
     GEOS_GEOMETRYCOLLECTION => :GeometryCollection,
 )
 
-function geomFromGEOS(ptr::Union{Geometry, Ptr{Cvoid}}, context::GEOSContext = get_global_context())
+function geomFromGEOS(
+    ptr::Union{Geometry,Ptr{Cvoid}},
+    context::GEOSContext = get_global_context(),
+)
     id = geomTypeId(ptr, context)
     if id == GEOS_POINT
         return Point(ptr, context)

--- a/test/test_geo_interface.jl
+++ b/test/test_geo_interface.jl
@@ -23,7 +23,8 @@ const LG = LibGEOS
     @test GeoInterface.getcoord(pt, 3) ≈ 3.0
     @test GeoInterface.testgeometry(pt)
     # This doesn't return the Z extent
-    @test_broken GeoInterface.extent(pt) == Extent(X = (1.0, 1.0), Y=(2.0, 2.0), Z=(3.0, 3.0))
+    @test_broken GeoInterface.extent(pt) ==
+                 Extent(X = (1.0, 1.0), Y = (2.0, 2.0), Z = (3.0, 3.0))
     plot(pt)
 
     pt = LibGEOS.Point(1, 2)
@@ -224,16 +225,40 @@ const LG = LibGEOS
 
     @testset "Conversion" begin
         one_arg_functions = (
-            LG.area, LG.geomLength, LG.envelope, LG.minimumRotatedRectangle, LG.convexhull, LG.boundary,
-            LG.uniquePoints, LG.unaryUnion, LG.pointOnSurface, LG.centroid, LG.node,
-            LG.delaunayTriangulationEdges, LG.delaunayTriangulation, LG.constrainedDelaunayTriangulation,
+            LG.area,
+            LG.geomLength,
+            LG.envelope,
+            LG.minimumRotatedRectangle,
+            LG.convexhull,
+            LG.boundary,
+            LG.uniquePoints,
+            LG.unaryUnion,
+            LG.pointOnSurface,
+            LG.centroid,
+            LG.node,
+            LG.delaunayTriangulationEdges,
+            LG.delaunayTriangulation,
+            LG.constrainedDelaunayTriangulation,
             # these have different signatures
             # LG.simplify, LG.topologyPreserveSimplify,
         )
         two_arg_functions = (
-            LG.intersection, LG.difference, LG.symmetricDifference, LG.union,
-            LG.distance, LG.hausdorffdistance, LG.nearestPoints, LG.disjoint, LG.touches, LG.intersects, LG.crosses,
-            LG.within, LG.overlaps, LG.covers, LG.coveredby, LG.equals,
+            LG.intersection,
+            LG.difference,
+            LG.symmetricDifference,
+            LG.union,
+            LG.distance,
+            LG.hausdorffdistance,
+            LG.nearestPoints,
+            LG.disjoint,
+            LG.touches,
+            LG.intersects,
+            LG.crosses,
+            LG.within,
+            LG.overlaps,
+            LG.covers,
+            LG.coveredby,
+            LG.equals,
             # these have different signatures
             # LG.project, LG.projectNormalized, LG.sharedPaths, LG.snap, LG.contains, LG.equalsexact,
         )
@@ -280,7 +305,8 @@ const LG = LibGEOS
         @test geom isa MultiLineString
         @test GeoInterface.coordinates(geom) == coords
         for f in one_arg_functions
-            @test f(LibGEOS.MultiLineString(coords)) == f(GeoInterface.MultiLineString(coords))
+            @test f(LibGEOS.MultiLineString(coords)) ==
+                  f(GeoInterface.MultiLineString(coords))
         end
         coords2 = [[[0.0, 10], [0.5, 10], [20.0, 20], [10.0, 10], [0.0, 10]]]
         for f in two_arg_functions
@@ -301,7 +327,7 @@ const LG = LibGEOS
         coords2 = [[[0.0, 10], [0.5, 10], [20.0, 20], [10.0, 10], [0.0, 10]]]
         for f in two_arg_functions
             @test f(LibGEOS.Polygon(coords), LibGEOS.Polygon(coords2)) ==
-            f(GeoInterface.Polygon(coords), LibGEOS.Polygon(coords2))
+                  f(GeoInterface.Polygon(coords), LibGEOS.Polygon(coords2))
         end
 
         pgeom = LibGEOS.prepareGeom(geom)

--- a/test/test_geos_functions.jl
+++ b/test/test_geos_functions.jl
@@ -69,13 +69,9 @@ end
     @test !LibGEOS.isCCW(a)
 
     # Polygons and Holes
-    shell = LibGEOS.LinearRing(
-        Vector{Float64}[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
-    )
-    hole1 =
-        LibGEOS.LinearRing(Vector{Float64}[[1, 8], [2, 8], [2, 9], [1, 9], [1, 8]])
-    hole2 =
-        LibGEOS.LinearRing(Vector{Float64}[[8, 1], [9, 1], [9, 2], [8, 2], [8, 1]])
+    shell = LibGEOS.LinearRing(Vector{Float64}[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]])
+    hole1 = LibGEOS.LinearRing(Vector{Float64}[[1, 8], [2, 8], [2, 9], [1, 9], [1, 8]])
+    hole2 = LibGEOS.LinearRing(Vector{Float64}[[8, 1], [9, 1], [9, 2], [8, 2], [8, 1]])
     polygon = LibGEOS.Polygon(shell, [hole1, hole2])
     @test LibGEOS.getGeomDimensions(polygon) == 2
     @test LibGEOS.geomTypeId(polygon) == LibGEOS.GEOS_POLYGON
@@ -443,12 +439,22 @@ end
     LibGEOS.destroyPreparedGeom(prepGeom1_)
 
     for (wkt1_, wkt2_, wkt3_, wkt4_) in [
-        ["POLYGON((1 1,1 5,5 5,5 1,1 1))", "POLYGON((8 8, 9 9, 9 10, 8 8))", "POINT(5 5)", "POINT(8 8)"],
+        [
+            "POLYGON((1 1,1 5,5 5,5 1,1 1))",
+            "POLYGON((8 8, 9 9, 9 10, 8 8))",
+            "POINT(5 5)",
+            "POINT(8 8)",
+        ],
         ["POLYGON((1 1,1 5,5 5,5 1,1 1))", "POINT(2 2)", "POINT(2 2)", "POINT(2 2)"],
         ["LINESTRING(1 5,5 5,5 1,1 1)", "POINT(2 2)", "POINT(2 1)", "POINT(2 2)"],
         ["LINESTRING(0 0,10 10)", "LINESTRING(0 10,10 0)", "POINT(5 5)", "POINT(5 5)"],
-        ["POLYGON((0 0,10 0,10 10,0 10,0 0))", "LINESTRING(8 5,12 5)", "POINT(8 5)", "POINT(8 5)"]
-        ]
+        [
+            "POLYGON((0 0,10 0,10 10,0 10,0 0))",
+            "LINESTRING(8 5,12 5)",
+            "POINT(8 5)",
+            "POINT(8 5)",
+        ],
+    ]
         geom1_ = LibGEOS.readgeom(wkt1_)
         geom2_ = LibGEOS.readgeom(wkt2_)
         geom3_ = LibGEOS.readgeom(wkt3_)
@@ -949,7 +955,8 @@ end
     lss = readgeom("LINESTRING EMPTY")
     @test lineMerge(lss) == readgeom("GEOMETRYCOLLECTION EMPTY")
 
-    @test LibGEOS.reverse(readgeom("LINESTRING(0 0, 1 1)")) == readgeom("LINESTRING(1 1, 0 0)")
+    @test LibGEOS.reverse(readgeom("LINESTRING(0 0, 1 1)")) ==
+          readgeom("LINESTRING(1 1, 0 0)")
 
     geo = readgeom("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
     mic = LibGEOS.maximumInscribedCircle(geo, 1e-4)

--- a/test/test_geos_types.jl
+++ b/test/test_geos_types.jl
@@ -10,13 +10,16 @@
 end
 
 # Function to test if a geomerty is valid and if its type matches the geometry ID and has the correct dimensions
-function testValidTypeDims(geom::LibGEOS.Geometry, typeid::LibGEOS.GEOSGeomTypes, dims::Integer)
+function testValidTypeDims(
+    geom::LibGEOS.Geometry,
+    typeid::LibGEOS.GEOSGeomTypes,
+    dims::Integer,
+)
     @test LibGEOS.isValid(geom)
     @test LibGEOS.geomTypeId(geom) == typeid
     @test LibGEOS.getGeomDimensions(geom) == dims
 end
-testValidTypeDims(point::LibGEOS.Point) =
-    testValidTypeDims(point, LibGEOS.GEOS_POINT, 0)
+testValidTypeDims(point::LibGEOS.Point) = testValidTypeDims(point, LibGEOS.GEOS_POINT, 0)
 testValidTypeDims(multipoint::LibGEOS.MultiPoint) =
     testValidTypeDims(multipoint, LibGEOS.GEOS_MULTIPOINT, 0)
 testValidTypeDims(linestring::LibGEOS.LineString) =
@@ -25,8 +28,7 @@ testValidTypeDims(multilinestring::LibGEOS.MultiLineString) =
     testValidTypeDims(multilinestring, LibGEOS.GEOS_MULTILINESTRING, 1)
 testValidTypeDims(ring::LibGEOS.LinearRing) =
     testValidTypeDims(ring, LibGEOS.GEOS_LINEARRING, 1)
-testValidTypeDims(poly::LibGEOS.Polygon) =
-    testValidTypeDims(poly, LibGEOS.GEOS_POLYGON, 2)
+testValidTypeDims(poly::LibGEOS.Polygon) = testValidTypeDims(poly, LibGEOS.GEOS_POLYGON, 2)
 testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
     testValidTypeDims(multipoly, LibGEOS.GEOS_MULTIPOLYGON, 2)
 
@@ -55,8 +57,9 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test LibGEOS.equals(point_ptr, point2D)
 
         # Test point made from polygon pointer --> should not work
-        @test_throws MethodError LibGEOS.Point(LibGEOS.Polygon(
-            [[[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0], [-2.0, -2.0]]]))
+        @test_throws MethodError LibGEOS.Point(
+            LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]),
+        )
 
         # Test point made with local context
         ctx = LibGEOS.GEOSContext()
@@ -78,30 +81,31 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         testValidTypeDims(mpoint_coord)
         @test GeoInterface.coordinates(mpoint_coord) == [[0.0, 0.0], [1.0, 1.0]]
         @test LibGEOS.numGeometries(mpoint_coord) == 2
-        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 1),
-                             point1)
-        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 2),
-                            point2)
+        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 1), point1)
+        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 2), point2)
 
         # Test MultiPoint made from MultiPoint pointer
         multipoint_ptr = LibGEOS.MultiPoint(mpoint_coord)
         testValidTypeDims(multipoint_ptr)
         @test LibGEOS.equals(multipoint_ptr, mpoint_coord)
-        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 1),
-                             LibGEOS.getGeometry(multipoint_ptr, 1))
-        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_coord, 2),
-                             LibGEOS.getGeometry(multipoint_ptr, 2))
+        @test LibGEOS.equals(
+            LibGEOS.getGeometry(mpoint_coord, 1),
+            LibGEOS.getGeometry(multipoint_ptr, 1),
+        )
+        @test LibGEOS.equals(
+            LibGEOS.getGeometry(mpoint_coord, 2),
+            LibGEOS.getGeometry(multipoint_ptr, 2),
+        )
 
         # Test MultiPoint made from Point pointer
-        mpoint_ptr = LibGEOS.MultiPoint(
-                             LibGEOS.getGeometry(mpoint_coord, 1))
+        mpoint_ptr = LibGEOS.MultiPoint(LibGEOS.getGeometry(mpoint_coord, 1))
         testValidTypeDims(mpoint_ptr)
-        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_ptr, 1),
-                             Point(0.0, 0.0))
+        @test LibGEOS.equals(LibGEOS.getGeometry(mpoint_ptr, 1), Point(0.0, 0.0))
 
         # Test MultiPoint made from Polygon pointer
-        @test_throws MethodError LibGEOS.MultiPoint(LibGEOS.Polygon(
-            [[[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0], [-2.0, -2.0]]]))
+        @test_throws MethodError LibGEOS.MultiPoint(
+            LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]),
+        )
 
         # Test MultiPoint made from vector of 1 point and 2 points
         point_coord1 = LibGEOS.MultiPoint([point1])
@@ -128,7 +132,7 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
 
     @testset "LineString" begin
         # Test LineString made from vectors
-        ls_coord = LibGEOS.LineString([[0.0, 0.0], [1.0, 1.0], [1.0,0.0]])
+        ls_coord = LibGEOS.LineString([[0.0, 0.0], [1.0, 1.0], [1.0, 0.0]])
         testValidTypeDims(ls_coord)
         @test LibGEOS.numCoordinates(ls_coord) == 3
 
@@ -138,8 +142,9 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test LibGEOS.equals(ls_coord, ls_ptr)
 
         # Test LineString made from polygon pointer
-        @test_throws MethodError LibGEOS.LineString(LibGEOS.Polygon(
-            [[[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0], [-2.0, -2.0]]]))
+        @test_throws MethodError LibGEOS.LineString(
+            LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]),
+        )
 
         # Test LineString made with local context
         ctx = LibGEOS.GEOSContext()
@@ -153,7 +158,10 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
 
     @testset "MultiLineString" begin
         # Test MultiLineString made from vectors
-        mls_coord = LibGEOS.MultiLineString([[[0.0, 0.0], [1.0, 1.0], [1.0,0.0]], [[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0]]])
+        mls_coord = LibGEOS.MultiLineString([
+            [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0]],
+            [[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0]],
+        ])
         testValidTypeDims(mls_coord)
         @test LibGEOS.numGeometries(mls_coord) == 2
 
@@ -163,8 +171,9 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test LibGEOS.equals(mls_coord, mls_ptr)
 
         # Test MultiLineString made from polygon pointer
-        @test_throws MethodError LibGEOS.MultiLineString(LibGEOS.Polygon(
-            [[[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0], [-2.0, -2.0]]]))
+        @test_throws MethodError LibGEOS.MultiLineString(
+            LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]),
+        )
 
         # Test MultiLineString made with local context
         ctx = LibGEOS.GEOSContext()
@@ -178,8 +187,13 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
 
     @testset "LinearRing" begin
         # Test LinearRing made from vectors
-        lr_coord = LibGEOS.LinearRing([[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0],
-        [-2.0, 2.0], [-2.0, -2.0]])
+        lr_coord = LibGEOS.LinearRing([
+            [-2.0, -2.0],
+            [2.0, -2.0],
+            [2.0, 2.0],
+            [-2.0, 2.0],
+            [-2.0, -2.0],
+        ])
         testValidTypeDims(lr_coord)
         @test LibGEOS.numCoordinates(lr_coord) == 5
 
@@ -189,8 +203,9 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test LibGEOS.equals(lr_ptr, lr_coord)
 
         # Test LinearRing made from polygon pointer
-        @test_throws MethodError LibGEOS.LinearRing(LibGEOS.Polygon(
-            [[[-2.0, -2.0], [2.0, 2.0],[-2.0,2.0], [-2.0, -2.0]]]))
+        @test_throws MethodError LibGEOS.LinearRing(
+            LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]),
+        )
 
         # Test LinearRing made with local context
         ctx = LibGEOS.GEOSContext()
@@ -206,14 +221,16 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
     @testset "Polygon" begin
         # Test polygon made from vectors
         poly_vec = LibGEOS.Polygon([
-            [[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0,2.0], [-2.0, -2.0]],
-            [[0.0, 0.0], [1.0, 1.0], [1.0,0.0], [0.0, 0.0]]])
+            [[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]],
+            [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ])
         testValidTypeDims(poly_vec)
         @test LibGEOS.area(poly_vec) == 15.5
         @test !LibGEOS.isEmpty(poly_vec)
-        @test LibGEOS.GeoInterface.coordinates(poly_vec) ==
-            [[[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0,2.0], [-2.0, -2.0]],
-             [[0.0, 0.0], [1.0, 1.0], [1.0,0.0], [0.0, 0.0]]]
+        @test LibGEOS.GeoInterface.coordinates(poly_vec) == [
+            [[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]],
+            [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ]
         @test length(LibGEOS.interiorRings(poly_vec)) == 1
 
         # Test polygon made from  polygon pointer
@@ -223,8 +240,13 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test length(LibGEOS.interiorRings(poly_vec)) == 1
 
         # Test polygon made from linear ring pointer
-        ring_ext = LibGEOS.LinearRing([[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0],
-                                       [-2.0, 2.0], [-2.0, -2.0]])
+        ring_ext = LibGEOS.LinearRing([
+            [-2.0, -2.0],
+            [2.0, -2.0],
+            [2.0, 2.0],
+            [-2.0, 2.0],
+            [-2.0, -2.0],
+        ])
         poly_ringptr = LibGEOS.Polygon(ring_ext)
 
         # tests that ring's geomTypeID is linear ring and dimensions is 1
@@ -245,14 +267,18 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         @test LibGEOS.area(poly_ring) == 16
         @test !LibGEOS.isEmpty(poly_ring)
         @test LibGEOS.GeoInterface.coordinates(poly_ring) ==
-            [[[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]
+              [[[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]]
         @test length(LibGEOS.interiorRings(poly_ring)) == 0
 
         # Test polygon made from multiple linear rings (exterior and interior)
-        ring_int1 = LibGEOS.LinearRing([[0.0, 0.0], [1.0, 1.0], [1.0,0.0],
-                                        [0.0, 0.0]])
-        ring_int2 = LibGEOS.LinearRing([[0.0, 0.0], [0.0, -1.0], [-1.0, -1.0],
-                                        [-1.0, 0.0], [0.0, 0.0]])
+        ring_int1 = LibGEOS.LinearRing([[0.0, 0.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]])
+        ring_int2 = LibGEOS.LinearRing([
+            [0.0, 0.0],
+            [0.0, -1.0],
+            [-1.0, -1.0],
+            [-1.0, 0.0],
+            [0.0, 0.0],
+        ])
 
         #1 ring
         poly_rings1 = LibGEOS.Polygon(ring_ext, [ring_int1])
@@ -265,10 +291,11 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
         testValidTypeDims(poly_rings2)
         @test LibGEOS.area(poly_rings2) == 14.5
         @test !LibGEOS.isEmpty(poly_rings2)
-        @test LibGEOS.GeoInterface.coordinates(poly_rings2) ==
-            [[[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]],
-            [[0.0, 0.0], [1.0, 1.0], [1.0,0.0],[0.0, 0.0]],
-             [[0.0, 0.0], [0.0, -1.0], [-1.0, -1.0],[-1.0, 0.0], [0.0, 0.0]]]
+        @test LibGEOS.GeoInterface.coordinates(poly_rings2) == [
+            [[-2.0, -2.0], [2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]],
+            [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+            [[0.0, 0.0], [0.0, -1.0], [-1.0, -1.0], [-1.0, 0.0], [0.0, 0.0]],
+        ]
         @test length(LibGEOS.interiorRings(poly_rings2)) == 2
 
         # Test Polygon made with local context
@@ -290,14 +317,13 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
     end
 
     @testset "MultiPolygon" begin
-        poly1 = LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0],
-                                  [-2.0, 2.0], [-2.0, -2.0]]])
-        poly2 = LibGEOS.Polygon([[[0.0, 0.0], [1.0, -1.0],
-                                  [1.0, 0.0], [0.0, 0.0]]])
+        poly1 = LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]])
+        poly2 = LibGEOS.Polygon([[[0.0, 0.0], [1.0, -1.0], [1.0, 0.0], [0.0, 0.0]]])
         # Test multipolygon made from vectors
         mpoly_coord = LibGEOS.MultiPolygon([
             [[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]],
-            [[[0.0, 0.0], [1.0, -1.0], [1.0, 0.0], [0.0, 0.0]]]])
+            [[[0.0, 0.0], [1.0, -1.0], [1.0, 0.0], [0.0, 0.0]]],
+        ])
         testValidTypeDims(mpoly_coord)
         @test LibGEOS.numGeometries(mpoly_coord) == 2
         @test LibGEOS.equals(LibGEOS.getGeometry(mpoly_coord, 1), poly1)
@@ -336,8 +362,7 @@ testValidTypeDims(multipoly::LibGEOS.MultiPolygon) =
 
     @testset "GeometryCollections" begin
         point = LibGEOS.Point(0.0, 0.0)
-        poly = LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0],
-                                  [-2.0, 2.0], [-2.0, -2.0]]])
+        poly = LibGEOS.Polygon([[[-2.0, -2.0], [2.0, 2.0], [-2.0, 2.0], [-2.0, -2.0]]])
         # Test GeometryCollection from list of geometry pointers
         geomcol_ptr_list = LibGEOS.GeometryCollection([point, poly])
         @test LibGEOS.isValid(geomcol_ptr_list)
@@ -365,13 +390,13 @@ end
 @testset "Multi threading" begin
     function f91(n)
         # adapted from https://github.com/JuliaGeo/LibGEOS.jl/issues/91#issuecomment-1267732709
-        contexts = [LibGEOS.GEOSContext() for i=1:Threads.nthreads()]
-        p = [[[-1.,-1],[+1,-1],[+1,+1],[-1,+1],[-1,-1]]]
-        Threads.@threads :static for i=1:n
+        contexts = [LibGEOS.GEOSContext() for i = 1:Threads.nthreads()]
+        p = [[[-1.0, -1], [+1, -1], [+1, +1], [-1, +1], [-1, -1]]]
+        Threads.@threads :static for i = 1:n
             ctx = contexts[Threads.threadid()]
             g1 = LibGEOS.Polygon(p, ctx)
             g2 = LibGEOS.Polygon(p, ctx)
-            for j=1:n
+            for j = 1:n
                 @test LibGEOS.intersects(g1, g2, ctx)
             end
         end
@@ -382,14 +407,14 @@ end
     @testset "clone" begin
         function f(n)
             # adapted from https://github.com/JuliaGeo/LibGEOS.jl/issues/91#issuecomment-1267732709
-            contexts = [LibGEOS.GEOSContext() for i=1:Threads.nthreads()]
-            p = LibGEOS.Polygon([[[-1.,-1],[+1,-1],[+1,+1],[-1,+1],[-1,-1]]])
-            Threads.@threads :static for i=1:n
+            contexts = [LibGEOS.GEOSContext() for i = 1:Threads.nthreads()]
+            p = LibGEOS.Polygon([[[-1.0, -1], [+1, -1], [+1, +1], [-1, +1], [-1, -1]]])
+            Threads.@threads :static for i = 1:n
                 ctx = contexts[Threads.threadid()]
-                g1 = LibGEOS.clone(p,ctx)
-                g2 = LibGEOS.clone(p,ctx)
-                for j=1:n
-                    @test intersects(g1,g2)
+                g1 = LibGEOS.clone(p, ctx)
+                g2 = LibGEOS.clone(p, ctx)
+                for j = 1:n
+                    @test intersects(g1, g2)
                 end
             end
             GC.gc(true)
@@ -407,11 +432,13 @@ end
         readgeom("POLYGON EMPTY")
         readgeom("POLYGON ((10 10, 20 40, 90 90, 90 10, 10 10))")
         readgeom("MULTILINESTRING ((5 0, 10 0), (0 0, 5 0))")
-        readgeom("GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))")
+        readgeom(
+            "GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))",
+        )
     ]
     for g1 in geos
         g2 = LibGEOS.clone(g1)
         @test g1 !== g2
-        @test LibGEOS.equals(g1,g2)
+        @test LibGEOS.equals(g1, g2)
     end
 end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -3,32 +3,32 @@ using LibGEOS
 import GeoInterface
 
 @testset "allow_global_context!" begin
-    Point(1,2,3)
+    Point(1, 2, 3)
     LibGEOS.allow_global_context!(false)
-    @test_throws ErrorException Point(1,2,3)
-    Point(1,2,3, LibGEOS.GEOSContext())
+    @test_throws ErrorException Point(1, 2, 3)
+    Point(1, 2, 3, LibGEOS.GEOSContext())
     LibGEOS.allow_global_context!(true) do
-        Point(1,2,3)
+        Point(1, 2, 3)
     end
-    @test_throws ErrorException Point(1,2,3)
+    @test_throws ErrorException Point(1, 2, 3)
     LibGEOS.allow_global_context!(true)
-    Point(1,2,3)
-    Point(1,2,3, LibGEOS.GEOSContext())
+    Point(1, 2, 3)
+    Point(1, 2, 3, LibGEOS.GEOSContext())
     LibGEOS.allow_global_context!(false) do
-        @test_throws ErrorException Point(1,2,3)
+        @test_throws ErrorException Point(1, 2, 3)
     end
-    Point(1,2,3)
+    Point(1, 2, 3)
 end
 
 @testset "Context mixing" begin
     ctx1 = LibGEOS.GEOSContext()
     ctx2 = LibGEOS.GEOSContext()
     ctx3 = LibGEOS.GEOSContext()
-    p = [[[-1.,-1],[+1,-1],[+1,+1],[-1,+1],[-1,-1]]]
+    p = [[[-1.0, -1], [+1, -1], [+1, +1], [-1, +1], [-1, -1]]]
     p1 = LibGEOS.Polygon(p, ctx1)
     p2 = LibGEOS.Polygon(p, ctx2)
 
-    q = [[[-1.,-1],[+1,-1],[+1,+1],[-1,+1],[-1,-1]]]
+    q = [[[-1.0, -1], [+1, -1], [+1, +1], [-1, +1], [-1, -1]]]
     q1 = LibGEOS.Polygon(q, ctx1)
     q2 = LibGEOS.Polygon(q, ctx2)
     @test LibGEOS.intersects(p1, q1)
@@ -50,11 +50,15 @@ end
     coordinates! = LibGEOS.coordinates!
     buf3 = zeros(3)
     buf2 = zeros(2)
-    @test coordinates!(buf3, readgeom("POINT(1 2 3)")) == Float64[1,2,3] == buf3
-    @test coordinates!(buf2, readgeom("POINT(1 2)")) == Float64[1,2] == buf2
-    @test coordinates!(buf2, readgeom("POINT(1 2)"), 1) == Float64[1,2] == buf2
-    @test coordinates!(buf2, readgeom("LINESTRING (130 240, 650 240)"), 1) == buf2 == [130, 240]
-    @test coordinates!(buf2, readgeom("LINESTRING (130 240, 650 240)"), 2) == buf2 == [650, 240]
+    @test coordinates!(buf3, readgeom("POINT(1 2 3)")) == Float64[1, 2, 3] == buf3
+    @test coordinates!(buf2, readgeom("POINT(1 2)")) == Float64[1, 2] == buf2
+    @test coordinates!(buf2, readgeom("POINT(1 2)"), 1) == Float64[1, 2] == buf2
+    @test coordinates!(buf2, readgeom("LINESTRING (130 240, 650 240)"), 1) ==
+          buf2 ==
+          [130, 240]
+    @test coordinates!(buf2, readgeom("LINESTRING (130 240, 650 240)"), 2) ==
+          buf2 ==
+          [650, 240]
 end
 
 @testset "hash eq" begin
@@ -69,34 +73,42 @@ end
     @test hash(pt1) != hash(pt2)
     @test !isequal(pt1, pt2)
     @test !isapprox(pt1, pt2)
-    @test !isapprox(pt1, pt2, atol=0, rtol=0)
-    @test isapprox(pt1, pt2, atol=0.2)
-    @test isapprox(pt1, pt2, rtol=0.1)
-    @test readgeom("LINESTRING (130 240, 650 240)") != readgeom("LINESTRING (130 240, -650 240)")
-    @test !(readgeom("LINESTRING (130 240, 650 240)") ≈ readgeom("LINESTRING (130 240, -650 240)"))
-    @test readgeom("LINESTRING (130 240, 650 240)") ≈ readgeom("LINESTRING (130 240, -650 240)") atol=1300
-    @test readgeom("LINESTRING (130 240, 650 240)") ≈ readgeom("LINESTRING (130 240, 650 240.00000001)")
+    @test !isapprox(pt1, pt2, atol = 0, rtol = 0)
+    @test isapprox(pt1, pt2, atol = 0.2)
+    @test isapprox(pt1, pt2, rtol = 0.1)
+    @test readgeom("LINESTRING (130 240, 650 240)") !=
+          readgeom("LINESTRING (130 240, -650 240)")
+    @test !(
+        readgeom("LINESTRING (130 240, 650 240)") ≈
+        readgeom("LINESTRING (130 240, -650 240)")
+    )
+    @test readgeom("LINESTRING (130 240, 650 240)") ≈
+          readgeom("LINESTRING (130 240, -650 240)") atol = 1300
+    @test readgeom("LINESTRING (130 240, 650 240)") ≈
+          readgeom("LINESTRING (130 240, 650 240.00000001)")
 
-    @test isapprox(readgeom("POLYGON((1 1,0 0,            1 2,2 2,2 4,1 1))"),
-                   readgeom("POLYGON((1 1,0 0.00000000001,1 2,2 2,2 4,1 1))"))
+    @test isapprox(
+        readgeom("POLYGON((1 1,0 0,            1 2,2 2,2 4,1 1))"),
+        readgeom("POLYGON((1 1,0 0.00000000001,1 2,2 2,2 4,1 1))"),
+    )
 
     pt = readgeom("POINT(-1 NaN)")
     @test isequal(pt, pt)
     @test pt != pt
     @test !(isapprox(pt, pt))
-    @test !(isapprox(pt, pt, atol=Inf))
+    @test !(isapprox(pt, pt, atol = Inf))
 
     pt = readgeom("POINT(0 NaN)")
     @test isequal(pt, pt)
     @test pt != pt
     @test !(isapprox(pt, pt))
-    @test !(isapprox(pt, pt, atol=Inf))
+    @test !(isapprox(pt, pt, atol = Inf))
 
     geo = readgeom("POLYGON((1 1,1 2,2 2,2 NaN,1 1))")
-    @test isequal(geo,geo)
+    @test isequal(geo, geo)
     @test geo != geo
     @test !(isapprox(geo, geo))
-    @test !(isapprox(geo, geo, atol=Inf))
+    @test !(isapprox(geo, geo, atol = Inf))
 
     geos = [
         readgeom("POINT(0.12345 2.000 0.1)"),
@@ -109,20 +121,22 @@ end
         readgeom("POLYGON((1 1,1 2,2 2,2.1 1,1 1))"),
         readgeom("LINESTRING (130 240, 650 240)"),
         readgeom("MULTILINESTRING ((5 0, 10 0), (0 0, 5 0))"),
-        readgeom("GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))"),
+        readgeom(
+            "GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))",
+        ),
         readgeom("MULTIPOINT(0 0, 5 0, 10 0)"),
     ]
     for g1 in geos
         for g2 in geos
             if g1 === g2
                 @test g1 == g2
-                @test isequal(g1,g2)
+                @test isequal(g1, g2)
                 @test hash(g1) == hash(g2)
-                @test isapprox(g1,g2)
+                @test isapprox(g1, g2)
             else
                 @test g1 != g2
-                @test !isequal(g1,g2)
-                @test !isapprox(g1,g2)
+                @test !isequal(g1, g2)
+                @test !isapprox(g1, g2)
                 @test hash(g1) != hash(g2)
             end
         end
@@ -136,11 +150,11 @@ end
 end
 
 @testset "performance hash eq" begin
-    pts1 = [[sin(x), cos(x), 1] for x in range(0, 2pi, length=1000)]
+    pts1 = [[sin(x), cos(x), 1] for x in range(0, 2pi, length = 1000)]
     pts1[end] = pts1[1]
     lr1 = LinearRing(pts1)
     pts2 = copy(pts1)
-    pts2[453] = 2*pts2[453]
+    pts2[453] = 2 * pts2[453]
     lr2 = LinearRing(pts2)
     @test !(lr1 == lr2)
     @test !isequal(lr1, lr2)
@@ -177,14 +191,16 @@ end
         readgeom("POLYGON EMPTY")
         readgeom("POLYGON ((10 10, 20 40, 90 90, 90 10, 10 10))")
         readgeom("MULTILINESTRING ((5 0, 10 0), (0 0, 5 0))")
-        readgeom("GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))")
-        ]
+        readgeom(
+            "GEOMETRYCOLLECTION (LINESTRING (1 2, 2 2), LINESTRING (2 1, 1 1), POLYGON ((0.5 1, 1 2, 1 1, 0.5 1)), POLYGON ((9 2, 9.5 1, 2 1, 2 2, 9 2)))",
+        )
+    ]
         geo2 = readgeom(sprint(show, geo))
         @test LibGEOS.equals(geo, geo2)
     end
-    p = Polygon([[[0.0, 0.0] for _ in 1:10000]])
+    p = Polygon([[[0.0, 0.0] for _ = 1:10000]])
     buf = IOBuffer()
-    print(IOContext(buf, :compact=>true), p)
+    print(IOContext(buf, :compact => true), p)
     seekstart(buf)
     s = read(buf, String)
     @test length(s) < 30


### PR DESCRIPTION
@jaakkor2 kindly made GEOS 3.12 available via https://github.com/JuliaPackaging/Yggdrasil/pull/7212.

This re-runs the wrapper for it. At the end of generator.jl we run JuliaFormatter for the whole package, so that is where most of the diff is coming from. But if you look at the diff of src/generated/libgeos_api.jl you can see new functions appearing. These can be properly wrapped when needed.

For GEOS 3.12 changes see here: https://libgeos.org/posts/2023-06-27-geos-3-12-released/
