### PR TITLE
fix error message

### DIFF
--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -157,12 +157,12 @@ end
 
 function GI.convert(
     t::Type{<:AbstractGeometry},
-    ::AbstractGeometryTrait,
+    tr::AbstractGeometryTrait,
     geom;
     context = nothing,
 )
     error(
-        "Cannot convert an object of $(of(geom)) with the $(of()) trait to a $t (yet). Please report an issue.",
+        "Cannot convert an object of $(typeof(geom)) with the $(typeof(tr)) trait to a $t (yet). Please report an issue.",
     )
 end
 


### PR DESCRIPTION
I've changed `of` to `typeof` and assigned the second input a variable name `tr`... this should fix the following issue:

```julia
ERROR: UndefVarError: `of` not defined
Stacktrace:
 [1] convert(t::Type{GeometryCollection}, ::GeoInterface.GeometryCollectionTrait, geom::Shapefile.Handle{Union{Missing, Shapefile.Polygon}}; context::Nothing)
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:164
 [2] convert(t::Type{GeometryCollection}, ::GeoInterface.GeometryCollectionTrait, geom::Shapefile.Handle{Union{Missing, Shapefile.Polygon}})
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:158
 [3] to_geos(trait::GeoInterface.GeometryCollectionTrait, geom::Shapefile.Handle{Union{Missing, Shapefile.Polygon}})
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:278
 [4] to_geos(geom::Shapefile.Handle{Union{Missing, Shapefile.Polygon}})
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:277
 [5] within(::Point, ::Shapefile.Handle{Union{Missing, Shapefile.Polygon}}; kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:337
 [6] within(::Point, ::Shapefile.Handle{Union{Missing, Shapefile.Polygon}})
   @ LibGEOS ~/.julia/packages/LibGEOS/8fzeY/src/geo_interface.jl:337
```