### PR TITLE
Ignore RecipesBase ambiguity in Aqua.jl checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ GeoInterfaceRecipes = "0329782f-3d07-4b52-b9f6-d3137cf03c7a"
 
 [compat]
 Aqua = "0.8"
-CEnum = "0.2, 0.3, 0.4"
 CEnum = "0.2, 0.3, 0.4, 0.5"
 Extents = "0.1.1"
 GEOS_jll = "3.12"

--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,16 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeoInterfaceRecipes = "0329782f-3d07-4b52-b9f6-d3137cf03c7a"
 
 [compat]
+Aqua = "0.8"
+CEnum = "0.2, 0.3, 0.4"
 CEnum = "0.2, 0.3, 0.4, 0.5"
 Extents = "0.1.1"
 GEOS_jll = "3.12"
 GeoInterface = "1"
 GeoInterfaceRecipes = "1"
+Plots = "1"
 RecipesBase = "1"
+Test = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,12 +16,14 @@ Extents = "0.1.1"
 GEOS_jll = "3.12"
 GeoInterface = "1"
 GeoInterfaceRecipes = "1"
+RecipesBase = "1"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Plots", "Test"]
+test = ["Aqua", "Plots", "RecipesBase", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,9 @@ if version != LibGEOS.GEOS_CAPI_VERSION
 end
 
 @testset "LibGEOS" begin
+    Aqua.test_all(LibGEOS;
+        ambiguities=(exclude=[RecipesBase.apply_recipe],),
+    )
     include("test_geos_types.jl")
     include("test_geos_functions.jl")
     include("test_geos_operations.jl")
@@ -22,7 +25,4 @@ end
     include("test_invalid_geometry.jl")
     include("test_strtree.jl")
     include("test_misc.jl")
-    Aqua.test_all(LibGEOS;
-        ambiguities=(exclude=[RecipesBase.apply_recipe],),
-    )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using GeoInterface, Extents
-using Test, LibGEOS
+using Test, LibGEOS, RecipesBase
 import Aqua
 
 version = LibGEOS.GEOSversion()
@@ -22,5 +22,7 @@ end
     include("test_invalid_geometry.jl")
     include("test_strtree.jl")
     include("test_misc.jl")
-    Aqua.test_all(LibGEOS)
+    Aqua.test_all(LibGEOS
+        ambiguities=(exclude=[RecipesBase.apply_recipe],),
+    )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ end
     include("test_invalid_geometry.jl")
     include("test_strtree.jl")
     include("test_misc.jl")
-    Aqua.test_all(LibGEOS
+    Aqua.test_all(LibGEOS;
         ambiguities=(exclude=[RecipesBase.apply_recipe],),
     )
 end


### PR DESCRIPTION
We cant fix this without adding a method to RecipesBase.jl

For now, lets skip the check.