### PR TITLE
Improve error message for not-implemented geometric types

### DIFF
--- a/src/geos_types.jl
+++ b/src/geos_types.jl
@@ -638,8 +638,9 @@ function geomFromGEOS(
         return MultiLineString(ptr, context)
     elseif id == GEOS_MULTIPOLYGON
         return MultiPolygon(ptr, context)
-    else
-        @assert id == GEOS_GEOMETRYCOLLECTION
+    elseif id == GEOS_GEOMETRYCOLLECTION
         return GeometryCollection(ptr, context)
+    else
+        throw(ErrorException("Geometric type with code $id not implemented."))
     end
 end


### PR DESCRIPTION
Master
```
julia> readgeom("CIRCULARSTRING(0 0,1 1,2 0)")
ERROR: AssertionError: id == GEOS_GEOMETRYCOLLECTION
```

This PR
```
julia> readgeom("CIRCULARSTRING(0 0,1 1,2 0)")
ERROR: Geometric type with code 8 not implemented.
```