### PR TITLE
Basic support for curved geometries

### DIFF
--- a/src/LibGEOS.jl
+++ b/src/LibGEOS.jl
@@ -8,12 +8,17 @@ using CEnum
 
 const GI = GeoInterface
 
-export GeometryCollection,
+export CircularString,
+    CompoundCurve,
+    CurvePolygon,
+    GeometryCollection,
     LineString,
     LinearRing,
+    MultiCurve,
     MultiLineString,
     MultiPoint,
     MultiPolygon,
+    MultiSurface,
     Point,
     Polygon,
     STRtree

--- a/src/geos_types.jl
+++ b/src/geos_types.jl
@@ -390,6 +390,113 @@ mutable struct GeometryCollection <: AbstractMultiGeometry
     )
 end
 
+mutable struct CircularString <: AbstractGeometry
+    ptr::GEOSGeom
+    context::GEOSContext
+    function CircularString(
+        obj::CircularString,
+        context::GEOSContext = get_global_context(),
+    )
+        circularstring = new(cloneGeom(obj, context), context)
+        finalizer(destroyGeom, circularstring)
+        circularstring
+    end
+    # create a circularstring from a circularstring pointer, otherwise error
+    function CircularString(obj::GEOSGeom, context::GEOSContext = get_global_context())
+        id = LibGEOS.geomTypeId(obj, context)
+        circularstring = if id == GEOS_CIRCULARSTRING
+            new(obj, context)
+        else
+            open_issue_if_conversion_makes_sense(CircularString, id)
+        end
+        finalizer(destroyGeom, circularstring)
+        circularstring
+    end
+end
+
+mutable struct CompoundCurve <: AbstractGeometry
+    ptr::GEOSGeom
+    context::GEOSContext
+    function CompoundCurve(obj::CompoundCurve, context::GEOSContext = get_global_context())
+        compoundcurve = new(cloneGeom(obj, context), context)
+        finalizer(destroyGeom, compoundcurve)
+        compoundcurve
+    end
+    # create a compoundcurve from a compoundcurve pointer, otherwise error
+    function CompoundCurve(obj::GEOSGeom, context::GEOSContext = get_global_context())
+        id = LibGEOS.geomTypeId(obj, context)
+        compoundcurve = if id == GEOS_COMPOUNDCURVE
+            new(obj, context)
+        else
+            open_issue_if_conversion_makes_sense(CompoundCurve, id)
+        end
+        finalizer(destroyGeom, compoundcurve)
+        compoundcurve
+    end
+end
+
+mutable struct CurvePolygon <: AbstractGeometry
+    ptr::GEOSGeom
+    context::GEOSContext
+    function CurvePolygon(obj::CurvePolygon, context::GEOSContext = get_global_context())
+        curvepolygon = new(cloneGeom(obj, context), context)
+        finalizer(destroyGeom, curvepolygon)
+        curvepolygon
+    end
+    function CurvePolygon(obj::GEOSGeom, context::GEOSContext = get_global_context())
+        id = LibGEOS.geomTypeId(obj, context)
+        curvepolygon = if id == GEOS_CURVEPOLYGON
+            new(obj, context)
+        else
+            open_issue_if_conversion_makes_sense(CurvePolygon, id)
+        end
+        finalizer(destroyGeom, curvepolygon)
+        curvepolygon
+    end
+end
+
+mutable struct MultiCurve <: AbstractGeometry
+    ptr::GEOSGeom
+    context::GEOSContext
+    function MultiCurve(obj::MultiCurve, context::GEOSContext = get_global_context())
+        multicurve = new(cloneGeom(obj, context), context)
+        finalizer(destroyGeom, multicurve)
+        multicurve
+    end
+    # create a compoundcurve from a compoundcurve pointer, otherwise error
+    function MultiCurve(obj::GEOSGeom, context::GEOSContext = get_global_context())
+        id = LibGEOS.geomTypeId(obj, context)
+        multicurve = if id == GEOS_MULTICURVE
+            new(obj, context)
+        else
+            open_issue_if_conversion_makes_sense(MultiCurve, id)
+        end
+        finalizer(destroyGeom, multicurve)
+        multicurve
+    end
+end
+
+mutable struct MultiSurface <: AbstractGeometry
+    ptr::GEOSGeom
+    context::GEOSContext
+    function MultiSurface(obj::MultiSurface, context::GEOSContext = get_global_context())
+        multisurface = new(cloneGeom(obj, context), context)
+        finalizer(destroyGeom, multisurface)
+        multisurface
+    end
+    # create a multisurface from a multisurface, otherwise error
+    function MultiSurface(obj::GEOSGeom, context::GEOSContext = get_global_context())
+        id = LibGEOS.geomTypeId(obj, context)
+        multisurface = if id == GEOS_MULTISURFACE
+            new(obj, context)
+        else
+            open_issue_if_conversion_makes_sense(MultiSurface, id)
+        end
+        finalizer(destroyGeom, multisurface)
+        multisurface
+    end
+end
+
 const Geometry = Union{
     Point,
     MultiPoint,
@@ -399,6 +506,11 @@ const Geometry = Union{
     Polygon,
     MultiPolygon,
     GeometryCollection,
+    CircularString,
+    CompoundCurve,
+    CurvePolygon,
+    MultiCurve,
+    MultiSurface,
 }
 
 """
@@ -439,6 +551,11 @@ const geomtypes = [
     MultiLineString,
     MultiPolygon,
     GeometryCollection,
+    CircularString,
+    CompoundCurve,
+    CurvePolygon,
+    MultiCurve,
+    MultiSurface,
 ]
 
 const HasCoordSeq = Union{LineString,LinearRing,Point}
@@ -573,6 +690,11 @@ typesalt(::Type{MultiPoint}) = 0x6213e67dbfd3b570
 typesalt(::Type{MultiPolygon}) = 0xff2f957b4cdb5832
 typesalt(::Type{Point}) = 0x4b5c101d3843160e
 typesalt(::Type{Polygon}) = 0xa5c895d62ef56723
+typesalt(::Type{CircularString}) = 0x78ba4f50813d8da9
+typesalt(::Type{CompoundCurve}) = 0x44258e194220dc61
+typesalt(::Type{CurvePolygon}) = 0xdd0a2660d0239f1d
+typesalt(::Type{MultiCurve}) = 0x0641e0678af4d103
+typesalt(::Type{MultiSurface}) = 0x9f6a2cba51468ea5
 
 function Base.hash(geo::AbstractGeometry, h::UInt)::UInt
     h = hash(typesalt(typeof(geo)), h)
@@ -617,6 +739,11 @@ const GEOMTYPE = Dict{GEOSGeomTypes,Symbol}(
     GEOS_MULTILINESTRING => :MultiLineString,
     GEOS_MULTIPOLYGON => :MultiPolygon,
     GEOS_GEOMETRYCOLLECTION => :GeometryCollection,
+    GEOS_CIRCULARSTRING => :CircularString,
+    GEOS_COMPOUNDCURVE => :CompoundCurve,
+    GEOS_CURVEPOLYGON => :CurvePolygon,
+    GEOS_MULTICURVE => :MultiCurve,
+    GEOS_MULTISURFACE => :MultiSurface,
 )
 
 function geomFromGEOS(
@@ -640,6 +767,16 @@ function geomFromGEOS(
         return MultiPolygon(ptr, context)
     elseif id == GEOS_GEOMETRYCOLLECTION
         return GeometryCollection(ptr, context)
+    elseif id == GEOS_CIRCULARSTRING
+        return CircularString(ptr, context)
+    elseif id == GEOS_COMPOUNDCURVE
+        return CompoundCurve(ptr, context)
+    elseif id == GEOS_CURVEPOLYGON
+        return CurvePolygon(ptr, context)
+    elseif id == GEOS_MULTICURVE
+        return MultiCurve(ptr, context)
+    elseif id == GEOS_MULTISURFACE
+        return MultiSurface(ptr, context)
     else
         throw(ErrorException("Geometric type with code $id not implemented."))
     end

--- a/test/test_geos_types.jl
+++ b/test/test_geos_types.jl
@@ -442,3 +442,23 @@ end
         @test LibGEOS.equals(g1, g2)
     end
 end
+
+@testset "Curved geometry types" begin
+    geos = [
+        readgeom("CIRCULARSTRING(0 0,1 1,2 0)")
+        readgeom("CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 2 2, 0 0)")
+        readgeom("CURVEPOLYGON ((0 0, 2 0, 0 2, 0 0))")
+        readgeom("CURVEPOLYGON (CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 2 2, 0 0))")
+        readgeom("COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 2 -1, 0 -1, 0 0))")
+        readgeom(
+            "CURVEPOLYGON (COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 2 -1, 0 -1, 0 0)))",
+        )
+        readgeom(
+            "MULTISURFACE (CURVEPOLYGON (CIRCULARSTRING (0 0, 1 1, 2 0, 3 -1, 4 0, 2 2, 0 0)))",
+        )
+        readgeom("MULTICURVE((1 0, 2 0))")
+    ]
+
+    @test all(geomLength.(geos) .≈ [pi, 4pi, 4 + 2 * sqrt(2), 4pi, pi + 4, pi + 4, 4pi, 1])
+    @test all(area.(geos) .≈ [0, 0, 2, 2pi, 0, pi / 2 + 2, 2pi, 0])
+end


### PR DESCRIPTION
Add basic support `CircularString`, `CompoundCurve`, `CurvePolygon`, `MultiCurve`, `MultiSurface`. Reading WKT tests added.

Lots of additional methods to be added for constructing geometries. Those should fall under `open_issue_if_conversion_makes_sense` for now.